### PR TITLE
Closes #161 - prevent completion handler from being called twice with…

### DIFF
--- a/Prox/Prox/Data/EventsController.swift
+++ b/Prox/Prox/Data/EventsController.swift
@@ -12,13 +12,11 @@ protocol EventsControllerDelegate: class {
 class EventsController {
     lazy var eventsDatabase: EventsDatabase = FakeEventsDatabase()
 
-    weak var delegate: EventsControllerDelegate?
-
-    func getEvents(forLocation location: CLLocation) {
+    func getEvents(forLocation location: CLLocation, completion: @escaping (([Event]?, Error?) -> Void)) {
         return eventsDatabase.getEvents(forLocation: location).upon { results in
             let events = results.flatMap { $0.successResult() }
             DispatchQueue.main.async {
-                self.delegate?.eventController(self, didUpdateEvents: events)
+                completion(events, nil)
             }
         }
     }

--- a/Prox/Prox/Utilities/EventNotificationsManager.swift
+++ b/Prox/Prox/Utilities/EventNotificationsManager.swift
@@ -7,7 +7,6 @@ import CoreLocation
 
 class EventNotificationsManager {
 
-    fileprivate var eventFetchCompletionHandler: (([Event]?, Error?) -> Void)?
     fileprivate var shouldFetchEvents: Bool {
         guard var lastLocationFetchTime = timeOfLastLocationUpdate else {
             return false
@@ -21,30 +20,15 @@ class EventNotificationsManager {
         return UserDefaults.standard.value(forKey: AppConstants.timeOfLastLocationUpdateKey) as? Date
     }
 
-    fileprivate lazy var eventsController: EventsController = {
-        let controller = EventsController()
-        controller.delegate = self
-        return controller
-    }()
+    fileprivate lazy var eventsController = EventsController()
 
-    func fetchEvents(forLocation location: CLLocation, completion: (([Event]?, Error?) -> Void)? = nil) {
+    func fetchEvents(forLocation location: CLLocation, completion: @escaping (([Event]?, Error?) -> Void)) {
         if shouldFetchEvents {
-            eventFetchCompletionHandler = completion
             print("Should fetch events")
-            eventsController.getEvents(forLocation: location)
+            eventsController.getEvents(forLocation: location, completion: completion)
             return
         }
         print("Should not fetch events")
-        completion?(nil, nil)
-    }
-}
-
-extension EventNotificationsManager: EventsControllerDelegate {
-    func eventController(_ eventController: EventsController, didUpdateEvents events: [Event]) {
-        eventFetchCompletionHandler?(events, nil)
-    }
-
-    func eventController(_ eventController: EventsController, didError error: Error) {
-        eventFetchCompletionHandler?(nil, error)
+        completion(nil, nil)
     }
 }


### PR DESCRIPTION
… unique callbacks.

NOTE: I was unable to reproduce the crash and, in any case, don't know how to
test this code so I don't know if this still works as expected - I fixed it
based on continued compilation.

The crash was caused because the delegate contained a mutable completion
handler which, if `fetchEvents` was called more than once, would be replaced,
having the same system completion handler called multiple times.

I removed the delegate in favor of a callback, which seemed simpler. If we
wanted to continue to use the delegate, we could pass a unique identifier into
the fetchEvents call and return that to the delegate, keeping a list of IDs to
completion handlers, but that seemed complicated.

@fluffyemily PLEASE test this when you review! :)