### PR TITLE
Add RemoteConfig (remotely changeable configuration).

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,7 @@ target 'Prox' do
 	pod 'Firebase/Core'
 	pod 'Firebase/Database'
 	pod 'Firebase/Auth'
+	pod 'Firebase/RemoteConfig'
 	pod 'EDSunriseSet'
 	pod 'BuddyBuildSDK'
 	pod 'BadgeSwift', '~> 3.0'
@@ -30,6 +31,7 @@ target 'ProxUITests' do
 	pod 'Firebase/Core'
 	pod 'Firebase/Database'
 	pod 'Firebase/Auth'
+	pod 'Firebase/RemoteConfig'
 	pod 'EDSunriseSet'
 	pod 'BadgeSwift', '~> 3.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,6 +27,9 @@ PODS:
   - Firebase/Database (3.8.0):
     - Firebase/Core
     - FirebaseDatabase (= 3.1.0)
+  - Firebase/RemoteConfig (3.8.0):
+    - Firebase/Core
+    - FirebaseRemoteConfig (= 1.3.1)
   - FirebaseAnalytics (3.5.1):
     - FirebaseCore (~> 3.4)
     - FirebaseInstanceID (~> 1.0)
@@ -43,6 +46,12 @@ PODS:
   - FirebaseDatabase (3.1.0):
     - FirebaseAnalytics (~> 3.4)
   - FirebaseInstanceID (1.0.8)
+  - FirebaseRemoteConfig (1.3.1):
+    - FirebaseAnalytics (~> 3.4)
+    - FirebaseInstanceID (~> 1.0)
+    - GoogleInterchangeUtilities (~> 1.2)
+    - GoogleSymbolUtilities (~> 1.1)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
   - GoogleInterchangeUtilities (1.2.2):
     - GoogleSymbolUtilities (~> 1.1)
   - GoogleSymbolUtilities (1.1.2)
@@ -67,6 +76,7 @@ DEPENDENCIES:
   - Firebase/Auth
   - Firebase/Core
   - Firebase/Database
+  - Firebase/RemoteConfig
 
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
@@ -80,11 +90,12 @@ SPEC CHECKSUMS:
   FirebaseCore: d0ed25f27b6f9158eccc439f1be6f92e81207e28
   FirebaseDatabase: 3ebb2edb6007c3f0f87b248f3fa212bde56a1468
   FirebaseInstanceID: ba1e640935235e5fac39dfa816fe7660e72e1a8a
+  FirebaseRemoteConfig: 383a9afe0a9291ada949e3f615257928a823b594
   GoogleInterchangeUtilities: d5bc4d88d5b661ab72f9d70c58d02ca8c27ad1f7
   GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
   GoogleToolboxForMac: 2b2596cbb7186865e98cadf2b1e262d851c2b168
   GTMSessionFetcher: a1f8ed39e4fe21c68957daed472c7afbcdf29166
 
-PODFILE CHECKSUM: e6b6b23b6b1158d71afa2aebcd73ce2bfb33490f
+PODFILE CHECKSUM: 7bdfa6b7ca737b15abb2905a68b20ffdb623d58b
 
 COCOAPODS: 1.1.1

--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		392F3D901DD20EAE00B44B01 /* PlacesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392F3D8F1DD20EAE00B44B01 /* PlacesController.swift */; };
+		392F3D971DD4395000B44B01 /* RemoteConfigDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */; };
+		39C4EC9D1DDB464200B53B77 /* RemoteConfigKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */; };
+		39C4EC9E1DDCA75400B53B77 /* RemoteConfigKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */; };
+		39C4EC9F1DDCA75500B53B77 /* RemoteConfigKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */; };
 		4F00E2C2201E3A088D934AE0 /* Pods_Prox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29190FCA903C1D1AF4C77316 /* Pods_Prox.framework */; };
 		7B29E7C31DA3EC360099AF38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B29E7C21DA3EC360099AF38 /* AppDelegate.swift */; };
 		7B29E7CA1DA3EC360099AF38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B29E7C91DA3EC360099AF38 /* Assets.xcassets */; };
@@ -95,6 +99,8 @@
 		29190FCA903C1D1AF4C77316 /* Pods_Prox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Prox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		324CE3415A3E66A0F7F7CF54 /* Pods-ProxUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.release.xcconfig"; sourceTree = "<group>"; };
 		392F3D8F1DD20EAE00B44B01 /* PlacesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PlacesController.swift; path = Data/PlacesController.swift; sourceTree = "<group>"; };
+		392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RemoteConfigDefaults.plist; sourceTree = "<group>"; };
+		39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteConfigKeys.swift; sourceTree = "<group>"; };
 		55740F6C4426324FDA569848 /* Pods-Prox.enterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.enterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.enterprise.xcconfig"; sourceTree = "<group>"; };
 		64E189E4D93A85A43CF269E2 /* Pods-ProxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxTests/Pods-ProxTests.debug.xcconfig"; sourceTree = "<group>"; };
 		75091F0A7DE7F3D6E008D07B /* Pods-Prox.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.debug.xcconfig"; sourceTree = "<group>"; };
@@ -243,6 +249,8 @@
 				7B29E7C91DA3EC360099AF38 /* Assets.xcassets */,
 				E65857E31DB6A75400CD18F8 /* Database */,
 				7BD5CC881DB0EB7400BCF50D /* GoogleService-Info.plist */,
+				392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */,
+				39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */,
 				E67146341DB5488D007A99E4 /* Extensions */,
 				7B29E7CE1DA3EC360099AF38 /* Info.plist */,
 				7B29E7CB1DA3EC360099AF38 /* LaunchScreen.storyboard */,
@@ -563,6 +571,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B561BBA1DAC02B90096D8BC /* hilton_location.gpx in Resources */,
+				392F3D971DD4395000B44B01 /* RemoteConfigDefaults.plist in Resources */,
 				7BD5CC891DB0EB7400BCF50D /* GoogleService-Info.plist in Resources */,
 				7B29E7CD1DA3EC360099AF38 /* LaunchScreen.storyboard in Resources */,
 				7B29E7CA1DA3EC360099AF38 /* Assets.xcassets in Resources */,
@@ -757,6 +766,7 @@
 				E67146361DB54896007A99E4 /* CLLocationManager.swift in Sources */,
 				E662FF4E1DC1861C0042C4A9 /* PlaceDetailsDescriptionView.swift in Sources */,
 				7B8651921DBFAF19002A666A /* PlaceUtilities.swift in Sources */,
+				39C4EC9D1DDB464200B53B77 /* RemoteConfigKeys.swift in Sources */,
 				E65857DE1DB69F4200CD18F8 /* ReviewProvider.swift in Sources */,
 				7BD5CC7F1DAFF07E00BCF50D /* GFGeoHash.m in Sources */,
 				7B50956E1DB53429007C54F0 /* HorizontalLineView.swift in Sources */,
@@ -786,6 +796,7 @@
 				7B50957A1DB65342007C54F0 /* TravelTimesProvider.swift in Sources */,
 				E68BD90D1DCA9E8E007B51A3 /* DayOfWeekTests.swift in Sources */,
 				E68BD90F1DCAAD6B007B51A3 /* OpenHoursTests.swift in Sources */,
+				39C4EC9F1DDCA75500B53B77 /* RemoteConfigKeys.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -794,6 +805,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B29E7E31DA3EC360099AF38 /* ProxUITests.swift in Sources */,
+				39C4EC9E1DDCA75400B53B77 /* RemoteConfigKeys.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Prox/Prox/Data/FirebasePlacesDatabase.swift
+++ b/Prox/Prox/Data/FirebasePlacesDatabase.swift
@@ -14,8 +14,6 @@ private let VENUES_PATH = ROOT_PATH + "venues/"
 private let GEOFIRE_PATH = VENUES_PATH + "locations/"
 private let DETAILS_PATH = VENUES_PATH + "details/"
 
-private let SEARCH_RADIUS_KM = 4.0 // TODO: set distance
-
 class FirebasePlacesDatabase: PlacesDatabase {
 
     private let placeDetailsRef: FIRDatabaseReference
@@ -31,9 +29,9 @@ class FirebasePlacesDatabase: PlacesDatabase {
      * Queries GeoFire to get the place keys around the given location and then queries Firebase to
      * get the place details for the place keys.
      */
-    func getPlaces(forLocation location: CLLocation) -> Future<[DatabaseResult<Place>]> {
+    func getPlaces(forLocation location: CLLocation, withRadius radius: Double) -> Future<[DatabaseResult<Place>]> {
         let queue = DispatchQueue.global(qos: .userInitiated)
-        let places = getPlaceKeys(aroundPoint: location).andThen(upon: queue) { (placeKeyToLoc) -> Future<[DatabaseResult<Place>]> in
+        let places = getPlaceKeys(aroundPoint: location, withRadius: radius).andThen(upon: queue) { (placeKeyToLoc) -> Future<[DatabaseResult<Place>]> in
             // TODO: limit the number of place details we look up. X closest places?
             // TODO: These should be ordered by display order
             return self.getPlaceDetails(fromKeys: Array(placeKeyToLoc.keys)).allFilled()
@@ -44,11 +42,11 @@ class FirebasePlacesDatabase: PlacesDatabase {
     /*
      * Queries GeoFire to find keys that represent locations around the given point.
      */
-    private func getPlaceKeys(aroundPoint location: CLLocation) -> Deferred<[String:CLLocation]> {
+    private func getPlaceKeys(aroundPoint location: CLLocation, withRadius radius: Double) -> Deferred<[String:CLLocation]> {
         let deferred = Deferred<[String:CLLocation]>()
         var placeKeyToLoc = [String:CLLocation]()
 
-        guard let circleQuery = geofire.query(at: location, withRadius: SEARCH_RADIUS_KM) else {
+        guard let circleQuery = geofire.query(at: location, withRadius: radius) else {
             deferred.fill(with: placeKeyToLoc)
             return deferred
         }

--- a/Prox/Prox/Data/PlacesDatabase.swift
+++ b/Prox/Prox/Data/PlacesDatabase.swift
@@ -10,5 +10,5 @@ import CoreLocation
  * A listing of all the places we'd want to show a user.
  */
 protocol PlacesDatabase {
-    func getPlaces(forLocation location: CLLocation) -> Future<[DatabaseResult<Place>]>
+    func getPlaces(forLocation location: CLLocation, withRadius: Double) -> Future<[DatabaseResult<Place>]>
 }

--- a/Prox/Prox/Data/TravelTimesProvider.swift
+++ b/Prox/Prox/Data/TravelTimesProvider.swift
@@ -2,13 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import FirebaseRemoteConfig
 import Foundation
 import MapKit
 
 struct TravelTimesProvider {
 
-    static let MIN_WALKING_TIME = 30
-    static let YOU_ARE_HERE_WALKING_TIME = 1
+    static var MIN_WALKING_TIME: Int = {
+        // Note that this is semantically maximum walking time, 
+        // rather than minimum walking time (as used throughout the codebase).
+        let key = RemoteConfigKeys.maxWalkingTimeInMins
+        return FIRRemoteConfig.remoteConfig()[key].numberValue!.intValue
+    }()
+
+    static var YOU_ARE_HERE_WALKING_TIME: Int = {
+        let key = RemoteConfigKeys.youAreHereWalkingTimeMins
+        return FIRRemoteConfig.remoteConfig()[key].numberValue!.intValue
+    }()
 
     private static func directions(fromLocation: CLLocationCoordinate2D, toLocation: CLLocationCoordinate2D, byTransitType transitType: MKDirectionsTransportType) -> MKDirections {
 

--- a/Prox/Prox/Info.plist
+++ b/Prox/Prox/Info.plist
@@ -52,5 +52,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
+	<key>FirebaseAutomaticScreenReportingEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/Prox/Prox/RemoteConfigDefaults.plist
+++ b/Prox/Prox/RemoteConfigDefaults.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>remote_config_cache_expiration</key>
 	<integer>43200</integer>
+	<key>search_radius_in_km</key>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Prox/Prox/RemoteConfigDefaults.plist
+++ b/Prox/Prox/RemoteConfigDefaults.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>remote_config_cache_expiration</key>
+	<integer>43200</integer>
+</dict>
+</plist>

--- a/Prox/Prox/RemoteConfigDefaults.plist
+++ b/Prox/Prox/RemoteConfigDefaults.plist
@@ -3,8 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>remote_config_cache_expiration</key>
-	<integer>43200</integer>
+	<real>43200</real>
 	<key>search_radius_in_km</key>
 	<integer>4</integer>
+	<key>you_are_here_walking_time_mins</key>
+	<integer>1</integer>
+	<key>max_walking_time_in_mins</key>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Prox/Prox/RemoteConfigKeys.swift
+++ b/Prox/Prox/RemoteConfigKeys.swift
@@ -31,4 +31,12 @@ class RemoteConfigKeys {
     // The search radius the app will use to query the Firebase database.
     // This is measured in kilometers. The default value is 4 km.
     public static let searchRadiusInKm = "search_radius_in_km"
+
+    // The minimum number of minutes walking to the venue to be considered at the venue.at
+    // This is measured in minutes. The default value is 1 minute.
+    public static let youAreHereWalkingTimeMins = "you_are_here_walking_time_mins"
+
+    // This is the maximum time interval that we display walking directions before switching to driving directions.
+    // This is measure in minutes. The default value is 30 minutes.
+    public static let maxWalkingTimeInMins = "max_walking_time_in_mins"
 }

--- a/Prox/Prox/RemoteConfigKeys.swift
+++ b/Prox/Prox/RemoteConfigKeys.swift
@@ -27,4 +27,8 @@ class RemoteConfigKeys {
     // more than remoteConfigCacheExpiration seconds ago. Thus the next fetch would go to the server unless
     // throttling is in progress. The default expiration duration is 43200 (12 hours).
     public static let remoteConfigCacheExpiration = "remote_config_cache_expiration"
+
+    // The search radius the app will use to query the Firebase database.
+    // This is measured in kilometers. The default value is 4 km.
+    public static let searchRadiusInKm = "search_radius_in_km"
 }

--- a/Prox/Prox/RemoteConfigKeys.swift
+++ b/Prox/Prox/RemoteConfigKeys.swift
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+ * This file holds the keys to values held in Firebase's RemoteConfig file.
+ * RemoteConfig allows us to change values remotely without going through 
+ * an AppStore release cycle.
+ * 
+ * Values can be changed in the Firebase RemoteConfig console.
+ * 
+ * The pattern to add a new value:
+ *
+ * 1. add a key to `RemoteConfigKeys`. You should document the value here.
+ * 2. add a default value to `RemoteConfigValues.plist`.
+ * 3. add a value to Firebase using the firebase/remote config console.
+ * 4. use the value in a lazy property, using the following as an example.
+ *
+ * return FIRRemoteConfig.remoteConfig()[key].numberValue!.doubleValue
+ *
+ */
+class RemoteConfigKeys {
+    // Expiration time of the current remote config.
+    // Any previously fetched and cached config would be considered expired because it would have been fetched
+    // more than remoteConfigCacheExpiration seconds ago. Thus the next fetch would go to the server unless
+    // throttling is in progress. The default expiration duration is 43200 (12 hours).
+    public static let remoteConfigCacheExpiration = "remote_config_cache_expiration"
+}


### PR DESCRIPTION
This adds three commits:

1. Firebase's RemoteConfig library, which is updated from the remote server. There is a pattern to add keys, defaults and values. The debug expiry time is 60 seconds.
2. Values for search radius that the app will query firebase for venues.
3. Maximum walking time to use before the user is told to drive.

From here on in, I'd recommend using this for any magic numbers, or strings, or arrays that will materially affect the business logic of the app.