### PR TITLE
Issue 218 - place update fixes

### DIFF
--- a/Prox.xcworkspace/xcshareddata/xcschemes/Prox.xcscheme
+++ b/Prox.xcworkspace/xcshareddata/xcschemes/Prox.xcscheme
@@ -81,6 +81,13 @@
             ReferencedContainer = "container:Prox/Prox.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
       <LocationScenarioReference

--- a/Prox/Prox/AppDelegate.swift
+++ b/Prox/Prox/AppDelegate.swift
@@ -14,6 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var placeCarouselViewController: PlaceCarouselViewController?
 
     private var authorizedUser: FIRUser?
+
+    let locationMonitor = LocationMonitor()
     
     private lazy var remoteConfigCacheExpiration: TimeInterval = {
         if AppConstants.isDebug {
@@ -39,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // create root view
         placeCarouselViewController = PlaceCarouselViewController()
+        locationMonitor.delegate = placeCarouselViewController
         window?.rootViewController = placeCarouselViewController
 
         if #available(iOS 10.0, *) {

--- a/Prox/Prox/Data/EventsController.swift
+++ b/Prox/Prox/Data/EventsController.swift
@@ -6,11 +6,6 @@ import Foundation
 
 import FirebaseRemoteConfig
 
-protocol EventsProviderDelegate: class {
-    func eventsProvider(_ eventsProvider: EventsProvider, didUpdateEvents: [Event])
-    func eventsProvider(_ eventsProvider: EventsProvider, didError error: Error)
-}
-
 class EventsProvider {
     lazy var eventsDatabase: EventsDatabase = FirebaseEventsDatabase()
 

--- a/Prox/Prox/Data/PlacesController.swift
+++ b/Prox/Prox/Data/PlacesController.swift
@@ -102,10 +102,10 @@ class PlacesProvider {
             success: { (task, data) in
                 // TODO is there anything useful we can get from the server to help the UI here?
                 // e.g. some JSON to give queue size (how busy is it).
-                print("Server responded ok.")
+                NSLog("Server responded ok.")
             },
             failure: { (task, err) in
-                print("Error from server: \(err)")
+                NSLog("Error from server: \(err)")
                 DispatchQueue.main.async {
                     self.delegate?.placesProvider(self, didError: err)
                 }

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -243,7 +243,7 @@ class PlaceCarouselViewController: UIViewController {
 
     fileprivate func fetchPlaces(forLocation location: CLLocation) {
         self.placesProvider.updatePlaces(forLocation: location)
-        let placeMonitoringRadius = RemoteConfigKeys.getDouble(forKey: RemoteConfigKeys.searchRadiusInKm) / 4
+        let placeMonitoringRadius = RemoteConfigKeys.searchRadiusInKm.value / 4
         locationMonitor.startMonitoring(location: location, withIdentifier: placesFetchMonitorIdentifier, withRadius: placeMonitoringRadius, forEntry: nil, forExit: { region in
             self.locationMonitor.stopMonitoringRegion(withIdentifier: placesFetchMonitorIdentifier)
             self.shouldFetchPlaces = true

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -243,7 +243,7 @@ class PlaceCarouselViewController: UIViewController {
 
     fileprivate func fetchPlaces(forLocation location: CLLocation) {
         self.placesProvider.updatePlaces(forLocation: location)
-        let placeMonitoringRadius = RemoteConfigKeys.searchRadiusInKm.value / 4
+        let placeMonitoringRadius = RemoteConfigKeys.getDouble(forKey: RemoteConfigKeys.searchRadiusInKm) / 4
         locationMonitor.startMonitoring(location: location, withIdentifier: placesFetchMonitorIdentifier, withRadius: placeMonitoringRadius, forEntry: nil, forExit: { region in
             self.locationMonitor.stopMonitoringRegion(withIdentifier: placesFetchMonitorIdentifier)
             self.shouldFetchPlaces = true

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -68,7 +68,7 @@ class PlaceCarouselViewController: UIViewController {
 
         return view
     }()
-
+ 
     // label displaying sunrise and sunset times
     lazy var sunriseSetTimesLabel: UILabel = {
         let label = UILabel()
@@ -77,11 +77,7 @@ class PlaceCarouselViewController: UIViewController {
         return label
     }()
 
-    lazy var locationMonitor: LocationMonitor = {
-        let monitor = LocationMonitor()
-        monitor.delegate = self
-        return monitor
-    }()
+    var locationMonitor: LocationMonitor { return (UIApplication.shared.delegate! as! AppDelegate).locationMonitor }
 
     lazy var placeCarousel: PlaceCarousel = {
         let carousel = PlaceCarousel()
@@ -193,22 +189,6 @@ class PlaceCarouselViewController: UIViewController {
         NSLayoutConstraint.activate(constraints, translatesAutoresizingMaskIntoConstraints: false)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        guard let location = locationMonitor.getCurrentLocation() else {
-            return
-        }
-
-        // this will update places when we first load, and whenever we show the place carousel
-        // but not update places while we are showing details, until we close the place details
-        // this ensures consistency between the place details and the carousel underneath
-        // and makes sure we don't end up providing weird data to users while they are scrolling
-        // through places details
-        updateLocation(location: location)
-        updatePlaces(forLocation: location)
-    }
-
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -244,15 +224,20 @@ class PlaceCarouselViewController: UIViewController {
         if sunriseSet == nil {
             updateSunRiseSetTimes(forLocation: location)
         }
+
+        updatePlaces(forLocation: location)
     }
 
     fileprivate func updatePlaces(forLocation location: CLLocation) {
-        if shouldFetchPlaces {
-            fetchPlaces(forLocation: location)
-        } else {
-            // re-sort places based on new location
-            let sortedPlaces = PlaceUtilities.sort(places: self.places, byDistanceFromLocation: location)
-            self.places = sortedPlaces
+        // don't bother fetching new places when in the background.
+        if UIApplication.shared.applicationState != .background {
+            if shouldFetchPlaces {
+                fetchPlaces(forLocation: location)
+            } else {
+                // re-sort places based on new location
+                let sortedPlaces = PlaceUtilities.sort(places: self.places, byDistanceFromLocation: location)
+                self.places = sortedPlaces
+            }
         }
     }
 
@@ -262,16 +247,6 @@ class PlaceCarouselViewController: UIViewController {
         locationMonitor.startMonitoring(location: location, withIdentifier: placesFetchMonitorIdentifier, withRadius: placeMonitoringRadius, forEntry: nil, forExit: { region in
             self.locationMonitor.stopMonitoringRegion(withIdentifier: placesFetchMonitorIdentifier)
             self.shouldFetchPlaces = true
-            // if we're currently in the background then dismiss the detail view if we have one
-            // this is so that we get fresh places when we open the app again
-            // right now I have no idea if this will kick of a places fetch immediately or when the app is next opened
-            // maybe I'll have to make some changes once I have figured that out
-            let state = UIApplication.shared.applicationState
-            if state == .background || state == .inactive {
-                DispatchQueue.main.async {
-                    self.presentedViewController?.dismiss(animated: false, completion: nil)
-                }
-            }
         })
         self.shouldFetchPlaces = false
     }
@@ -340,10 +315,11 @@ extension PlaceCarouselViewController: PlaceDataSource {
     }
 
     func previousPlace(forPlace place: Place) -> Place? {
-        guard let currentPlaceIndex = places.index(where: {$0 == place}),
-            currentPlaceIndex > places.startIndex else {
-                return nil
+        guard let currentPlaceIndex = places.index(where: {$0 == place}) else {
+                return places[places.startIndex]
         }
+
+        guard currentPlaceIndex > places.startIndex else { return nil }
 
         return places[places.index(before: currentPlaceIndex)]
     }
@@ -380,14 +356,16 @@ extension PlaceCarouselViewController: LocationMonitorDelegate {
     func locationMonitorNeedsUserPermissionsPrompt(_ locationMonitor: LocationMonitor) {
         presentSettingsOrQuitPrompt()
     }
+
+    func locationMonitor(_ locationMonitor: LocationMonitor, userDidExitCurrentLocation location: CLLocation) {
+        locationMonitor.refreshLocation()
+    }
 }
 
 extension PlaceCarouselViewController: PlacesProviderDelegate {
     func placesProviderWillStartFetchingPlaces(_ controller: PlacesProvider) {
         // TODO placeholder for the waiting state.
-        if self.places.count == 0 {
-            headerView.numberOfPlacesLabel.text = "Waiting"
-        }
+        headerView.numberOfPlacesLabel.text = "Waiting"
     }
 
     func placesProviderDidFinishFetchingPlaces(_ controller: PlacesProvider) {
@@ -399,6 +377,8 @@ extension PlaceCarouselViewController: PlacesProviderDelegate {
 
     func placesProvider(_ controller: PlacesProvider, didReceivePlaces places: [Place]) {
         self.places = places
+
+        (self.presentedViewController as? PlaceDetailViewController)?.placesUpdated()
     }
 
     func placesProvider(_ controller: PlacesProvider, didError error: Error) {

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -306,20 +306,19 @@ class PlaceCarouselViewController: UIViewController {
 extension PlaceCarouselViewController: PlaceDataSource {
 
     func nextPlace(forPlace place: Place) -> Place? {
-        guard let currentPlaceIndex = places.index(where: {$0 == place}),
-            currentPlaceIndex + 1 < places.endIndex else {
-                return nil
+        // if the place isn't in the list, make the first item in the list the next item
+        guard let currentPlaceIndex = places.index(where: {$0 == place}) else {
+            return places[places.startIndex]
         }
+
+        guard currentPlaceIndex + 1 < places.endIndex else { return nil }
 
         return places[places.index(after: currentPlaceIndex)]
     }
 
     func previousPlace(forPlace place: Place) -> Place? {
-        guard let currentPlaceIndex = places.index(where: {$0 == place}) else {
-                return places[places.startIndex]
-        }
-
-        guard currentPlaceIndex > places.startIndex else { return nil }
+        guard let currentPlaceIndex = places.index(where: {$0 == place}),
+            currentPlaceIndex > places.startIndex else { return nil }
 
         return places[places.index(before: currentPlaceIndex)]
     }

--- a/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
@@ -132,6 +132,38 @@ class PlaceDetailViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+
+    func placesUpdated() {
+        mapButtonBadge.text = "\(dataSource?.numberOfPlaces() ?? 0)"
+
+        if let nextPlace = dataSource?.nextPlace(forPlace: currentCardViewController.place) {
+            if let nextCardViewController = nextCardViewController {
+                nextCardViewController.place = nextPlace
+            } else {
+                nextCardViewController = dequeuePlaceCardViewController(forPlace: nextPlace)
+                scrollView.addSubview(nextCardViewController!.cardView)
+                nextCardViewLeadingConstraint = nextCardViewController!.cardView.leadingAnchor.constraint(equalTo: currentCardViewController.cardView.trailingAnchor, constant: cardViewSpacingConstant)
+                NSLayoutConstraint.activate( [nextCardViewController!.cardView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: cardViewTopAnchorConstant),
+                                nextCardViewController!.cardView.widthAnchor.constraint(equalToConstant: cardViewWidth),
+                                nextCardViewLeadingConstraint!], translatesAutoresizingMaskIntoConstraints: false)
+            }
+        }
+        if let previousPlace = dataSource?.previousPlace(forPlace: currentCardViewController.place) {
+            if let previousCardViewController = previousCardViewController {
+                previousCardViewController.place = previousPlace
+            } else  {
+                previousCardViewController = dequeuePlaceCardViewController(forPlace: previousPlace)
+                scrollView.addSubview(previousCardViewController!.cardView)
+                previousCardViewTrailingConstraint = previousCardViewController!.cardView.trailingAnchor.constraint(equalTo: currentCardViewController.cardView.leadingAnchor, constant: -cardViewSpacingConstant)
+                NSLayoutConstraint.activate( [previousCardViewController!.cardView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: cardViewTopAnchorConstant),
+                                previousCardViewController!.cardView.widthAnchor.constraint(equalToConstant: cardViewWidth),
+                                previousCardViewTrailingConstraint!], translatesAutoresizingMaskIntoConstraints: false)
+            }
+        }
+
+        view.setNeedsLayout()
+    }
+
     fileprivate func setBackgroundImage(toPhotoAtURL photoURLString: String?) {
         if let imageURLString = photoURLString,
             let imageURL = URL(string: imageURLString) {

--- a/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
@@ -147,7 +147,11 @@ class PlaceDetailViewController: UIViewController {
                                 nextCardViewController!.cardView.widthAnchor.constraint(equalToConstant: cardViewWidth),
                                 nextCardViewLeadingConstraint!], translatesAutoresizingMaskIntoConstraints: false)
             }
+        } else {
+            nextCardViewController?.cardView.removeFromSuperview()
+            nextCardViewController?.removeFromParentViewController()
         }
+
         if let previousPlace = dataSource?.previousPlace(forPlace: currentCardViewController.place) {
             if let previousCardViewController = previousCardViewController {
                 previousCardViewController.place = previousPlace
@@ -159,6 +163,9 @@ class PlaceDetailViewController: UIViewController {
                                 previousCardViewController!.cardView.widthAnchor.constraint(equalToConstant: cardViewWidth),
                                 previousCardViewTrailingConstraint!], translatesAutoresizingMaskIntoConstraints: false)
             }
+        } else {
+            previousCardViewController?.cardView.removeFromSuperview()
+            previousCardViewController?.removeFromParentViewController()
         }
 
         view.setNeedsLayout()

--- a/Prox/Prox/RemoteConfigDefaults.plist
+++ b/Prox/Prox/RemoteConfigDefaults.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>significant_location_change_distance_meters</key>
+	<string>100</string>
 	<key>min_time_from_end_of_event_for_notifications_mins</key>
 	<string>120</string>
 	<key>max_travel_time_to_event_mins</key>

--- a/Prox/Prox/RemoteConfigKeys.swift
+++ b/Prox/Prox/RemoteConfigKeys.swift
@@ -67,6 +67,7 @@ class RemoteConfigKeys {
     public static let maxEventDurationForNotificationsMins = "max_duration_of_event_for_notification_mins"
     public static let maxTravelTimesToEventMins = "max_travel_time_to_event_mins"
     public static let minTimeFromEndOfEventForNotificationMins = "min_time_from_end_of_event_for_notifications_mins"
+    public static let significantLocationChangeDistanceMeters = "significant_location_change_distance_meters"
 
     // a csv of categories UX wants us to hide.
     public static let placeCategoriesToHideCSV = "place_categories_to_hide_csv"

--- a/Prox/Prox/Utilities/LocationMonitor.swift
+++ b/Prox/Prox/Utilities/LocationMonitor.swift
@@ -46,7 +46,7 @@ class LocationMonitor: NSObject {
         manager.desiredAccuracy = kCLLocationAccuracyBest
         // TODO: update to a more sane distance value when testing is over.
         // This is probably going to be around 100m
-        manager.distanceFilter = kCLDistanceFilterNone
+        manager.distanceFilter = RemoteConfigKeys.getDouble(forKey: RemoteConfigKeys.significantLocationChangeDistanceMeters)
         manager.pausesLocationUpdatesAutomatically = true
         return manager
     }()

--- a/Prox/Prox/Utilities/LocationMonitor.swift
+++ b/Prox/Prox/Utilities/LocationMonitor.swift
@@ -84,7 +84,7 @@ class LocationMonitor: NSObject {
         delegate?.locationMonitor(self, userDidVisitLocation: currentLocation)
     }
 
-    func startMonitoringCurrentLocation() {
+    func startMonitoringForVisitAtCurrentLocation() {
         guard let currentLocation = getCurrentLocation() else { return }
         startTimeAtLocationTimer()
         startMonitoring(location: currentLocation, withIdentifier: currentLocationIdentifier, withRadius: AppConstants.currentLocationMonitoringRadius, forEntry: nil, forExit: { region in
@@ -101,7 +101,7 @@ class LocationMonitor: NSObject {
         self.locationManager.startMonitoring(for: region.region)
     }
 
-    fileprivate func stopMonitoringRegion(withIdentifier identifier: String) {
+    func stopMonitoringRegion(withIdentifier identifier: String) {
         guard let monitoredRegion = monitoredRegions[identifier]?.region else {
             return
         }


### PR DESCRIPTION
New place update strategy

- When app loads, take current location and monitor a region with a radius of search_radius_in_km/4 kms around that location. 
- Set Flag saying don't fetch places
- When user exists that monitored region, set flag saying fetch places
- If the user is in the background, dismiss the detail view, triggering a fetch of new places immediately
- When user next returns to the carousel screen, fetch new places
- If user opens app or returns to the carousel screen and no new places need to be fetched, resort the current places based on the users location

My simulator has stopped notifying the app on location changes so I have not been able to test this. Will spend tomorrow riding around London on a bus ensuring that this works as expected, but I thought I would raise the PR so the code can get reviewed while I am doing that.

Also tagged both @jhugman & @mcomella to get more eyes on the code