### PR TITLE
Add Flurry analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ xcuserdata/
 
 # Secure Information
 Prox/Prox/GoogleService-Info.plist
+Prox/Prox/APIKeys.plist
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ target 'Prox' do
 	pod 'Firebase/Database'
 	pod 'Firebase/Auth'
 	pod 'Firebase/RemoteConfig'
+    pod 'Flurry-iOS-SDK/FlurrySDK'
 	pod 'EDSunriseSet'
 	pod 'BuddyBuildSDK'
 	pod 'BadgeSwift', '~> 3.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -52,6 +52,7 @@ PODS:
     - GoogleInterchangeUtilities (~> 1.2)
     - GoogleSymbolUtilities (~> 1.1)
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - Flurry-iOS-SDK/FlurrySDK (7.8.1)
   - FXPageControl (1.4)
   - GoogleInterchangeUtilities (1.2.2):
     - GoogleSymbolUtilities (~> 1.1)
@@ -78,6 +79,7 @@ DEPENDENCIES:
   - Firebase/Core
   - Firebase/Database
   - Firebase/RemoteConfig
+  - Flurry-iOS-SDK/FlurrySDK
   - FXPageControl (= 1.4)
 
 SPEC CHECKSUMS:
@@ -93,12 +95,13 @@ SPEC CHECKSUMS:
   FirebaseDatabase: 3ebb2edb6007c3f0f87b248f3fa212bde56a1468
   FirebaseInstanceID: ba1e640935235e5fac39dfa816fe7660e72e1a8a
   FirebaseRemoteConfig: 383a9afe0a9291ada949e3f615257928a823b594
+  Flurry-iOS-SDK: 3d1daff95d43b8fead3bb43590d54c6e8244d410
   FXPageControl: 5057bf21537579b40ff30e119cd425d16d8ef90a
   GoogleInterchangeUtilities: d5bc4d88d5b661ab72f9d70c58d02ca8c27ad1f7
   GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
   GoogleToolboxForMac: 2b2596cbb7186865e98cadf2b1e262d851c2b168
   GTMSessionFetcher: a1f8ed39e4fe21c68957daed472c7afbcdf29166
 
-PODFILE CHECKSUM: 1a7be293519adba2ae2c33e63485fbf548317cfc
+PODFILE CHECKSUM: bc14f242ef24f4392a58f0205f4a9778542dd932
 
 COCOAPODS: 1.1.1

--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		234AF15A1DDFD91C00097B0B /* AnalyticsUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */; };
 		392F3D901DD20EAE00B44B01 /* PlacesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392F3D8F1DD20EAE00B44B01 /* PlacesController.swift */; };
 		392F3D971DD4395000B44B01 /* RemoteConfigDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */; };
 		39C4EC9D1DDB464200B53B77 /* RemoteConfigKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */; };
@@ -111,6 +112,7 @@
 		0EA57261799D082127AF0A24 /* Pods-ProxTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxTests/Pods-ProxTests.release.xcconfig"; sourceTree = "<group>"; };
 		18F1C6CC1D18EC45A9072FF1 /* Pods-ProxUITests.enterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.enterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.enterprise.xcconfig"; sourceTree = "<group>"; };
 		1E318DF6890B9E7221222152 /* Pods-Prox.enterprise kona.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.enterprise kona.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.enterprise kona.xcconfig"; sourceTree = "<group>"; };
+		234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsUtilities.swift; sourceTree = "<group>"; };
 		246E3C4ADD7C4DD2150C111B /* Pods-Prox.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.release.xcconfig"; sourceTree = "<group>"; };
 		29190FCA903C1D1AF4C77316 /* Pods_Prox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Prox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		324CE3415A3E66A0F7F7CF54 /* Pods-ProxUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -360,6 +362,7 @@
 				7B9D15C51DC0D2E70051B760 /* OpenInHelper.swift */,
 				7BA05BEA1DD4D602009AC121 /* EventNotificationsManager.swift */,
 				E6101A971DDA7B8500D05B74 /* CategoriesUtil.swift */,
+				234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -796,6 +799,7 @@
 				E63C346F1DDCDFBB005B6B15 /* LocationLoadingView.swift in Sources */,
 				7B5095721DB5352E007C54F0 /* Colors.swift in Sources */,
 				7B48EBDA1DD1F679005C36CB /* GeofenceRegion.swift in Sources */,
+				234AF15A1DDFD91C00097B0B /* AnalyticsUtilities.swift in Sources */,
 				E662FF4A1DC022940042C4A9 /* PlaceDetailsCardView.swift in Sources */,
 				E6101A981DDA7B8500D05B74 /* CategoriesUtil.swift in Sources */,
 				7B561BB31DABD5C90096D8BC /* PlaceCarouselHeaderView.swift in Sources */,

--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		23039CD41DE56D5200653FCD /* APIKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 23039CD31DE56D5200653FCD /* APIKeys.plist */; };
 		234AF15A1DDFD91C00097B0B /* AnalyticsUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */; };
 		2380CA911DE4140A002D73F1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2380CA901DE4140A002D73F1 /* AppState.swift */; };
 		392F3D901DD20EAE00B44B01 /* PlacesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392F3D8F1DD20EAE00B44B01 /* PlacesController.swift */; };
@@ -113,6 +114,7 @@
 		0EA57261799D082127AF0A24 /* Pods-ProxTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxTests/Pods-ProxTests.release.xcconfig"; sourceTree = "<group>"; };
 		18F1C6CC1D18EC45A9072FF1 /* Pods-ProxUITests.enterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.enterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.enterprise.xcconfig"; sourceTree = "<group>"; };
 		1E318DF6890B9E7221222152 /* Pods-Prox.enterprise kona.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.enterprise kona.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.enterprise kona.xcconfig"; sourceTree = "<group>"; };
+		23039CD31DE56D5200653FCD /* APIKeys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = APIKeys.plist; sourceTree = "<group>"; };
 		234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsUtilities.swift; sourceTree = "<group>"; };
 		2380CA901DE4140A002D73F1 /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		246E3C4ADD7C4DD2150C111B /* Pods-Prox.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.release.xcconfig"; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				E6101A8F1DDA45CD00D05B74 /* Data.bundle */,
 				E65857E31DB6A75400CD18F8 /* Database */,
 				7BD5CC881DB0EB7400BCF50D /* GoogleService-Info.plist */,
+				23039CD31DE56D5200653FCD /* APIKeys.plist */,
 				392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */,
 				39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */,
 				E67146341DB5488D007A99E4 /* Extensions */,
@@ -622,6 +625,7 @@
 			files = (
 				7B561BBA1DAC02B90096D8BC /* hilton_location.gpx in Resources */,
 				392F3D971DD4395000B44B01 /* RemoteConfigDefaults.plist in Resources */,
+				23039CD41DE56D5200653FCD /* APIKeys.plist in Resources */,
 				7BD5CC891DB0EB7400BCF50D /* GoogleService-Info.plist in Resources */,
 				7B29E7CD1DA3EC360099AF38 /* LaunchScreen.storyboard in Resources */,
 				7B29E7CA1DA3EC360099AF38 /* Assets.xcassets in Resources */,

--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		234AF15A1DDFD91C00097B0B /* AnalyticsUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */; };
+		2380CA911DE4140A002D73F1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2380CA901DE4140A002D73F1 /* AppState.swift */; };
 		392F3D901DD20EAE00B44B01 /* PlacesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392F3D8F1DD20EAE00B44B01 /* PlacesController.swift */; };
 		392F3D971DD4395000B44B01 /* RemoteConfigDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */; };
 		39C4EC9D1DDB464200B53B77 /* RemoteConfigKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */; };
@@ -113,6 +114,7 @@
 		18F1C6CC1D18EC45A9072FF1 /* Pods-ProxUITests.enterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.enterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.enterprise.xcconfig"; sourceTree = "<group>"; };
 		1E318DF6890B9E7221222152 /* Pods-Prox.enterprise kona.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.enterprise kona.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.enterprise kona.xcconfig"; sourceTree = "<group>"; };
 		234AF1591DDFD91C00097B0B /* AnalyticsUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsUtilities.swift; sourceTree = "<group>"; };
+		2380CA901DE4140A002D73F1 /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		246E3C4ADD7C4DD2150C111B /* Pods-Prox.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.release.xcconfig"; sourceTree = "<group>"; };
 		29190FCA903C1D1AF4C77316 /* Pods_Prox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Prox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		324CE3415A3E66A0F7F7CF54 /* Pods-ProxUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 				7B5095641DB531CA007C54F0 /* Place.swift */,
 				7B48EBD91DD1F679005C36CB /* GeofenceRegion.swift */,
 				7BA05BE41DD4CCB1009AC121 /* Event.swift */,
+				2380CA901DE4140A002D73F1 /* AppState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -570,7 +573,7 @@
 				TargetAttributes = {
 					7B29E7BE1DA3EC360099AF38 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -821,6 +824,7 @@
 				7B9DA1571DBE6EE300A68C82 /* PlaceCarouselViewController.swift in Sources */,
 				7B5095671DB53378007C54F0 /* PlaceCarouselCollectionViewCell.swift in Sources */,
 				7B5095751DB62590007C54F0 /* NSLayoutConstraint.swift in Sources */,
+				2380CA911DE4140A002D73F1 /* AppState.swift in Sources */,
 				7BD5CC7D1DAFF07E00BCF50D /* GeoFire.m in Sources */,
 				E67146361DB54896007A99E4 /* CLLocationManager.swift in Sources */,
 				E662FF4E1DC1861C0042C4A9 /* PlaceDetailsDescriptionView.swift in Sources */,

--- a/Prox/Prox/AppDelegate.swift
+++ b/Prox/Prox/AppDelegate.swift
@@ -29,7 +29,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+
         Analytics.startAppSession()
+        // Start session measuring Loading duration
+        Analytics.startSession(sessionName: AppState.State.loading.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
+
         setupFirebase()
         setupRemoteConfig()
         BuddyBuildSDK.setup()
@@ -116,11 +120,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // if there is a timer running, cancel it. We'll wait until background app refresh fires instead
         placeCarouselViewController?.locationMonitor.cancelTimeAtLocationTimer()
         eventsNotificationsManager.persistNotificationCache()
+        AppState.enterBackground()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
         placeCarouselViewController?.locationMonitor.startTimeAtLocationTimer()
+        AppState.enterForeground()
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
@@ -132,6 +138,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         placeCarouselViewController?.locationMonitor.cancelTimeAtLocationTimer()
         eventsNotificationsManager.persistNotificationCache()
+        AppState.exiting()
     }
 
     func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {

--- a/Prox/Prox/AppDelegate.swift
+++ b/Prox/Prox/AppDelegate.swift
@@ -29,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        Analytics.startAppSession()
         setupFirebase()
         setupRemoteConfig()
         BuddyBuildSDK.setup()
@@ -179,6 +180,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         if response.notification.request.content.categoryIdentifier == "EVENTS" {
             if let eventKey = response.notification.request.content.userInfo[notificationEventIDKey] as? String {
+                Analytics.logEvent(event: AnalyticsEvent.EVENT_NOTIFICATION, params: [:])
                 placeCarouselViewController?.openPlaceForEvent(withKey: eventKey)
             }
         }

--- a/Prox/Prox/AppDelegate.swift
+++ b/Prox/Prox/AppDelegate.swift
@@ -27,7 +27,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var eventsNotificationsManager: EventNotificationsManager!
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
         Analytics.startAppSession()

--- a/Prox/Prox/Models/AppState.swift
+++ b/Prox/Prox/Models/AppState.swift
@@ -9,6 +9,8 @@ class AppState {
         case loading, details, carousel, background, exiting, unknown
     }
 
+    private static var cardVisits = Set<Int>()
+
     // Initial app state
     private static var state = State.loading
     private static var preBackgroundState: State?
@@ -44,7 +46,13 @@ class AppState {
 
     private static func updateSessionState(newState: State) {
         print("[debug] Previous state: " + state.rawValue)
-        Analytics.endSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
+        var params: [String: Any] = [:]
+        if (cardVisits.count > 0) {
+            params[AnalyticsEvent.NUM_CARDS] = cardVisits.count
+            print(cardVisits.count)
+            cardVisits.removeAll()
+        }
+        Analytics.endSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: params)
 
         print("[debug] New state: " + newState.rawValue)
         state = newState
@@ -52,5 +60,9 @@ class AppState {
         if (state != State.exiting) {
             Analytics.startSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
         }
+    }
+
+    static func trackCardVisit(cardPos: Int) {
+        cardVisits.insert(cardPos)
     }
 }

--- a/Prox/Prox/Models/AppState.swift
+++ b/Prox/Prox/Models/AppState.swift
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+class AppState {
+    enum State: String {
+        case loading, details, carousel, background, exiting, unknown
+    }
+
+    // Initial app state
+    private static var state = State.loading
+    private static var preBackgroundState: State?
+
+    static func getState() -> State {
+        return state
+    }
+
+    static func enterBackground() {
+        print("[debug] entering background from: " + state.rawValue)
+        preBackgroundState = state
+        updateSessionState(newState: State.background)
+    }
+
+    static func enterForeground() {
+        let safeState = preBackgroundState != nil ? preBackgroundState! : State.unknown
+        print("[debug] resuming to preBackground state: " + safeState.rawValue)
+        updateSessionState(newState: safeState)
+        preBackgroundState = nil
+    }
+
+    static func enterCarousel() {
+        updateSessionState(newState: State.carousel)
+    }
+
+    static func enterDetails() {
+        updateSessionState(newState: State.details)
+    }
+
+    static func exiting() {
+        updateSessionState(newState: State.exiting)
+    }
+
+    private static func updateSessionState(newState: State) {
+        print("[debug] Previous state: " + state.rawValue)
+        Analytics.endSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
+
+        print("[debug] New state: " + newState.rawValue)
+        state = newState
+
+        if (state != State.exiting) {
+            Analytics.startSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
+        }
+    }
+}

--- a/Prox/Prox/Models/AppState.swift
+++ b/Prox/Prox/Models/AppState.swift
@@ -49,8 +49,11 @@ class AppState {
         var params: [String: Any] = [:]
         if (cardVisits.count > 0) {
             params[AnalyticsEvent.NUM_CARDS] = cardVisits.count
-            print(cardVisits.count)
+            print("[debug] total cards seen: \(cardVisits.count)")
             cardVisits.removeAll()
+
+            // Try to close a Detail card session, it's okay if it doesn't exist
+            Analytics.endSession(sessionName: AnalyticsEvent.DETAILS_CARD_SESSION_DURATION, params: [:])
         }
         Analytics.endSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: params)
 
@@ -63,6 +66,9 @@ class AppState {
     }
 
     static func trackCardVisit(cardPos: Int) {
+        // Try to close any Detail card sessions.
+        Analytics.endSession(sessionName: AnalyticsEvent.DETAILS_CARD_SESSION_DURATION, params: [:])
         cardVisits.insert(cardPos)
+        Analytics.startSession(sessionName: AnalyticsEvent.DETAILS_CARD_SESSION_DURATION, params: [AnalyticsEvent.CARD_INDEX: cardPos])
     }
 }

--- a/Prox/Prox/PlaceCarousel/PlaceCarousel.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarousel.swift
@@ -55,6 +55,7 @@ class PlaceCarousel: NSObject {
         guard let indexPath = indexPathFor(place: place) else {
            return
         }
+        AppState.trackCardVisit(cardPos: indexPath[1])
         carousel.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
     }
 
@@ -149,6 +150,10 @@ fileprivate class CarouselFlowLayout: UICollectionViewFlowLayout {
         let currentPage = velocity.x > 0 ? floor(rawPageValue) : ceil(rawPageValue)
         let nextPage = velocity.x > 0 ? ceil(rawPageValue) : floor(rawPageValue)
 
+        if (currentPage >= 0 && nextPage >= 0) {
+            AppState.trackCardVisit(cardPos: Int(currentPage))
+            AppState.trackCardVisit(cardPos: Int(nextPage))
+        }
         let pannedLessThanAPage = fabs(1 + currentPage - rawPageValue) > 0.5
         let flicked = fabs(velocity.x) > flickVelocity
 

--- a/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
@@ -143,6 +143,9 @@ class PlaceDetailViewController: UIViewController {
 
     init(place: Place) {
         super.init(nibName: nil, bundle: nil)
+
+        AppState.enterDetails()
+
         self.currentCardViewController = dequeuePlaceCardViewController(forPlace: place)
         self.currentCardViewController.cardView.alpha = 1
         self.currentCardViewController.cardView.transform = .identity
@@ -695,6 +698,7 @@ class PlaceDetailViewController: UIViewController {
 
     func close() {
         Analytics.logEvent(event: AnalyticsEvent.MAP_BUTTON, params: [:])
+        AppState.enterCarousel()
         self.dismiss(animated: true, completion: nil)
 
     }

--- a/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
@@ -694,6 +694,7 @@ class PlaceDetailViewController: UIViewController {
     }
 
     func close() {
+        Analytics.logEvent(event: AnalyticsEvent.MAP_BUTTON, params: [:])
         self.dismiss(animated: true, completion: nil)
 
     }

--- a/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailViewController.swift
@@ -145,6 +145,8 @@ class PlaceDetailViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         AppState.enterDetails()
+        let index = dataSource != nil ? dataSource!.index(forPlace: place) ?? 0 : 0
+        AppState.trackCardVisit(cardPos: index)
 
         self.currentCardViewController = dequeuePlaceCardViewController(forPlace: place)
         self.currentCardViewController.cardView.alpha = 1
@@ -517,6 +519,7 @@ class PlaceDetailViewController: UIViewController {
 
         let springDamping:CGFloat = newNextCardViewController == nil ? 0.8 : 1.0
         setupConstraints(forNewPreviousCard: currentCardViewController, newCurrentCard: nextCardViewController, newNextCard: newNextCardViewController)
+        AppState.trackCardVisit(cardPos: (dataSource?.index(forPlace: nextCardViewController.place))!)
 
         view.layoutIfNeeded()
 
@@ -587,6 +590,7 @@ class PlaceDetailViewController: UIViewController {
 
         let springDamping:CGFloat = newPreviousCardViewController == nil ? 0.8 : 1.0
         setupConstraints(forNewPreviousCard: newPreviousCardViewController, newCurrentCard: previousCardViewController, newNextCard: currentCardViewController)
+        AppState.trackCardVisit(cardPos: (dataSource?.index(forPlace: previousCardViewController.place))!)
 
         view.layoutIfNeeded()
 

--- a/Prox/Prox/PlaceDetails/PlaceDetailsCardView.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailsCardView.swift
@@ -135,7 +135,8 @@ class PlaceDetailsCardView: UIView {
     lazy var wikiDescriptionView: PlaceDetailsDescriptionView = {
         let view = PlaceDetailsDescriptionView(labelText: "Wikipedia summary",
                                         icon: UIImage(named: "logo_wikipedia"),
-                                        horizontalMargin: 16)
+                                        horizontalMargin: 16,
+                                        type: DetailType.wikipedia)
         let underlineAttribute = [NSUnderlineStyleAttributeName : NSUnderlineStyle.styleSingle.rawValue]
         let underlineAttributedString = NSAttributedString(string: "Read more on Wikipedia", attributes: underlineAttribute)
         view.readMoreLink.attributedText = underlineAttributedString
@@ -145,7 +146,8 @@ class PlaceDetailsCardView: UIView {
     lazy var yelpDescriptionView: PlaceDetailsDescriptionView = {
         let view = PlaceDetailsDescriptionView(labelText: "Yelp top review",
                                                                icon: UIImage(named: "logo_yelp_small"),
-                                                               horizontalMargin: 16)
+                                                               horizontalMargin: 16,
+                                                               type: DetailType.yelp)
         let underlineAttribute = [NSUnderlineStyleAttributeName : NSUnderlineStyle.styleSingle.rawValue]
         let underlineAttributedString = NSAttributedString(string: "Read more on Yelp", attributes: underlineAttribute)
         view.readMoreLink.attributedText = underlineAttributedString

--- a/Prox/Prox/PlaceDetails/PlaceDetailsCardViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailsCardViewController.swift
@@ -148,6 +148,8 @@ class PlaceDetailsCardViewController: UIViewController {
            let url = URL(string: urlString) else { return }
         if !OpenInHelper.open(url: url) {
             print("lol unable to open web address")
+        } else {
+            Analytics.logEvent(event: AnalyticsEvent.WEBSITE, params: [:])
         }
     }
 
@@ -155,6 +157,8 @@ class PlaceDetailsCardViewController: UIViewController {
         guard let url = URL(string: place.yelpProvider.url) else { return }
         if !OpenInHelper.open(url: url) {
             print("lol unable to open yelp review")
+        } else {
+            Analytics.logEvent(event: AnalyticsEvent.YELP, params: [:])
         }
     }
 
@@ -163,6 +167,8 @@ class PlaceDetailsCardViewController: UIViewController {
             let url = URL(string: tripAdvisorProvider.url) else { return }
         if !OpenInHelper.open(url: url) {
             print("lol unable to open trip advisor review")
+        } else {
+            Analytics.logEvent(event: AnalyticsEvent.TRIPADVISOR, params: [:])
         }
     }
 
@@ -173,6 +179,8 @@ class PlaceDetailsCardViewController: UIViewController {
 
         if !OpenInHelper.openRoute(fromLocation: location.coordinate, toPlace: place, by: transportType) {
             print("lol unable to open travel directions")
+        } else {
+            Analytics.logEvent(event: AnalyticsEvent.DIRECTIONS, params: [AnalyticsEvent.PARAM_ACTION: transportString])
         }
     }
 
@@ -182,6 +190,8 @@ class PlaceDetailsCardViewController: UIViewController {
             let url = URL(string: urlString) else { return }
         if !OpenInHelper.open(url: url) {
             print("lol unable to open web address")
+        } else {
+            Analytics.logEvent(event: AnalyticsEvent.EVENT_BANNER_LINK, params: [:])
         }
     }
 

--- a/Prox/Prox/PlaceDetails/PlaceDetailsDescriptionView.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailsDescriptionView.swift
@@ -11,6 +11,7 @@ fileprivate enum UIMode {
 class PlaceDetailsDescriptionView: UIView {
 
     private let CollapseExpandSeconds = 1.0
+    private let toggleEventType: String
 
     let horizontalMargin: CGFloat
 
@@ -95,6 +96,8 @@ class PlaceDetailsDescriptionView: UIView {
          icon: UIImage?,
          horizontalMargin: CGFloat) {
         self.horizontalMargin = horizontalMargin
+        toggleEventType = labelText == "Yelp top review" ? AnalyticsEvent.YELP_TOGGLE : AnalyticsEvent.WIKIPEDIA_TOGGLE
+
         super.init(frame: .zero)
 
         logoView.image = icon
@@ -143,6 +146,8 @@ class PlaceDetailsDescriptionView: UIView {
     }
 
     func didTap() {
+        let action = uiMode == .collapsed ? "expand" : "collapse"
+        Analytics.logEvent(event: toggleEventType, params: [AnalyticsEvent.PARAM_ACTION: action])
         setExpandableView(isExpanded: uiMode == .collapsed)
     }
 

--- a/Prox/Prox/PlaceDetails/PlaceDetailsDescriptionView.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailsDescriptionView.swift
@@ -8,6 +8,10 @@ fileprivate enum UIMode {
     case collapsed, expanded
 }
 
+enum DetailType {
+    case wikipedia, yelp
+}
+
 class PlaceDetailsDescriptionView: UIView {
 
     private let CollapseExpandSeconds = 1.0
@@ -94,9 +98,10 @@ class PlaceDetailsDescriptionView: UIView {
 
     init(labelText: String,
          icon: UIImage?,
-         horizontalMargin: CGFloat) {
+         horizontalMargin: CGFloat,
+         type: DetailType) {
         self.horizontalMargin = horizontalMargin
-        toggleEventType = labelText == "Yelp top review" ? AnalyticsEvent.YELP_TOGGLE : AnalyticsEvent.WIKIPEDIA_TOGGLE
+        toggleEventType = type == DetailType.yelp ? AnalyticsEvent.YELP_TOGGLE : AnalyticsEvent.WIKIPEDIA_TOGGLE
 
         super.init(frame: .zero)
 

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -51,6 +51,7 @@ public struct AnalyticsEvent {
     static let WEBSITE            = "website_link"
     static let MAP_BUTTON         = "map_button" // For returning to the Carousel
     static let NUM_CARDS          = "num_cards"
+    static let CARD_INDEX         = "card_index"
 
     // Event Actions
     static let EVENT_BANNER_LINK  = "event_banner_link"

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -50,8 +50,7 @@ public struct AnalyticsEvent {
     static let DIRECTIONS         = "directions_link"
     static let WEBSITE            = "website_link"
     static let MAP_BUTTON         = "map_button" // For returning to the Carousel
-    static let NUM_DETAILS_CARDS  = "num_details"
-    static let NUM_CAROUSEL_CARDS = "num_carousel"
+    static let NUM_CARDS          = "num_cards"
 
     // Event Actions
     static let EVENT_BANNER_LINK  = "event_banner_link"

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -7,23 +7,29 @@ import Flurry_iOS_SDK
 
 class Analytics {
     static func startAppSession() {
+        // TODO: Load key
         Flurry.logEvent(AnalyticsEvent.APP_INIT)
     }
 
-    static func logEvent(event: String, params: [String: String]) {
+    static func logEvent(event: String, params: [String: Any]) {
         Flurry.logEvent(event, withParameters: params)
+    }
+
+    static func startSession(sessionName: String, params: [String: Any]) {
+        Flurry.logEvent(sessionName, withParameters: params, timed: true)
+    }
+
+    static func endSession(sessionName: String, params: [String: Any]) {
+        Flurry.endTimedEvent(sessionName, withParameters: params)
     }
 }
 
 public struct AnalyticsEvent {
     static let APP_INIT = "app_init";
 
-    // Durations
-    static let LOADING_SCREEN_DURATION         = "loading_screen_duration"
-    static let PLACE_DETAILS_SESSION_DURATION  = "details_session_duration"
-    static let DETAILS_CARD_SESSION_DURATION   =
-        "details_card_session_duration"
-    static let PLACE_CAROUSEL_SESSION_DURATION = "carousel_session_duration"
+    static let SESSION_SUFFIX = "_session_duration"
+    static let DETAILS_CARD_SESSION_DURATION   = "details_card" + SESSION_SUFFIX
+
 
     // Place Details
     static let YELP               = "yelp_link"

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -6,8 +6,18 @@ import Foundation
 import Flurry_iOS_SDK
 
 class Analytics {
+
     static func startAppSession() {
-        // TODO: Load key
+        guard let apiPlistPath = Bundle.main.path(forResource: AppConstants.APIKEYS_PATH, ofType: "plist") else {
+            fatalError("Unable to load API keys plist. Did you include the API keys plist file?")
+        }
+
+        let keysDict = NSDictionary(contentsOfFile: apiPlistPath) as! [String: String]
+        guard let flurryKey = keysDict["FLURRY"] else {
+            print("No Flurry key! Not collecting analytics.")
+            return
+        }
+        Flurry.startSession(flurryKey)
         Flurry.logEvent(AnalyticsEvent.APP_INIT)
     }
 

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Flurry_iOS_SDK
+
+class Analytics {
+    static func startAppSession() {
+        Flurry.logEvent(AnalyticsEvent.APP_INIT)
+    }
+
+    static func logEvent(event: String, params: [String: String]) {
+        Flurry.logEvent(event, withParameters: params)
+    }
+}
+
+public struct AnalyticsEvent {
+    static let APP_INIT = "app_init";
+
+    // Durations
+    static let LOADING_SCREEN_DURATION         = "loading_screen_duration"
+    static let PLACE_DETAILS_SESSION_DURATION  = "details_session_duration"
+    static let DETAILS_CARD_SESSION_DURATION   =
+        "details_card_session_duration"
+    static let PLACE_CAROUSEL_SESSION_DURATION = "carousel_session_duration"
+
+    // Place Details
+    static let YELP               = "yelp_link"
+    static let YELP_TOGGLE        = "yelp_review_toggle"
+    static let TRIPADVISOR        = "tripadvisor_link"
+    static let WIKIPEDIA          = "wikipedia_link"
+    static let WIKIPEDIA_TOGGLE   = "wikipedia_toggle"
+    static let DIRECTIONS         = "directions_link"
+    static let WEBSITE            = "website_link"
+    static let MAP_BUTTON         = "map_button" // For returning to the Carousel
+    static let NUM_DETAILS_CARDS  = "num_details"
+    static let NUM_CAROUSEL_CARDS = "num_carousel"
+
+    // Event Actions
+    static let EVENT_BANNER_LINK  = "event_banner_link"
+    static let EVENT_NOTIFICATION = "event_notification"
+
+    static let PARAM_ACTION = "action"
+}

--- a/Prox/Prox/Utilities/AppConstants.swift
+++ b/Prox/Prox/Utilities/AppConstants.swift
@@ -91,4 +91,6 @@ public struct AppConstants {
             return URL(string: "https://prox-dev.moo.mx")!
         #endif
     }()
+
+    public static let APIKEYS_PATH = "APIKeys"
 }

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ compilation failures:
 
     open Prox.xcworkspace
 
-### GoogleServices-Info.plist
-For a successful build, you need the `Prox/Prox/GoogleService-Info.plist` file
-which contains secure information to connect to Firebase and our backend
-services. *Please do not add this file to version control.*
+### Services and API keys
+For a successful build, you need the `Prox/Prox/GoogleService-Info.plist` and
+`Prox/Prox/APIKeys.plist` files, which contain secure information to connect
+to Firebase, our backend services, and APIs. *Please do not add this file to
+version control.*
 
 If you are a team member, this file is available in the Engineering gdrive. If
 you are not, please contact a team member directly to discuss receiving this

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 cp $BUDDYBUILD_SECURE_FILES/GoogleService-Info.plist $BUDDYBUILD_WORKSPACE/Prox/Prox/GoogleService-Info.plist
+cp $BUDDYBUILD_SECURE_FILES/APIKeys.plist $BUDDYBUILD_WORKSPACE/Prox/Prox/APIKeys.plist


### PR DESCRIPTION
Opening a pull request for feedback.

After adding the newly required plist, Prox will send events to Flurry.

Still to do:
* Add unique card view count for Details or Carousel
* Investigate why some timed event durations are 0 in the Flurry dashboard
* Add remote config load timer?