### PR TITLE
Issue 277 - Fix  header layout issue on 6+/7 devices

### DIFF
--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -156,7 +156,7 @@ class PlaceCarouselViewController: UIViewController {
         view.addSubview(headerView)
 
         // setting up the layout constraints
-        constraints.append(contentsOf: [headerView.topAnchor.constraint(equalTo: view.topAnchor),
+        constraints.append(contentsOf: [headerView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor),
                                         headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                                         headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                                         headerView.heightAnchor.constraint(equalToConstant: 150)])


### PR DESCRIPTION
Just changed the top constraint to be the topLayoutGuide.topAnchor instead of the view to properly set it to the top.