### PR TITLE
Issue 281 - Force carousel images to clipToBounds

### DIFF
--- a/Prox/Prox/PlaceDetails/ImageCarouselCollectionViewCell.swift
+++ b/Prox/Prox/PlaceDetails/ImageCarouselCollectionViewCell.swift
@@ -11,6 +11,7 @@ class ImageCarouselCollectionViewCell: UICollectionViewCell {
         imageView.contentMode = .scaleAspectFill
         imageView.backgroundColor = .clear
         imageView.isOpaque = false
+        imageView.clipsToBounds = true
         return imageView
     }()
 


### PR DESCRIPTION
Was hard to find a place to reproduce it but the Palace Hotel in SF had images that overlapped. Setting the image to clipsToBounds seems to do the trick.