### PR TITLE
Closes #403 add events to places array

### DIFF
--- a/Prox/Prox/Data/TravelTimesProvider.swift
+++ b/Prox/Prox/Data/TravelTimesProvider.swift
@@ -18,6 +18,10 @@ struct TravelTimesProvider {
         return RemoteConfigKeys.youAreHereWalkingTimeMins.value
     }()
 
+    static var travelTimePadding: Double = {
+        return RemoteConfigKeys.travelTimePaddingMins.value * 60
+    }()
+
     private static func directions(fromLocation: CLLocationCoordinate2D, toLocation: CLLocationCoordinate2D, byTransitType transitType: MKDirectionsTransportType) -> MKDirections {
 
         let directionsRequest = MKDirectionsRequest()
@@ -85,7 +89,7 @@ struct TravelTimesProvider {
                 let drivingTime = travelTimes.drivingTime else {
                     return completion(false)
             }
-            let travelTimePadding = RemoteConfigKeys.travelTimePaddingMins.value * 60
+            let travelTimePadding = TravelTimesProvider.travelTimePadding
             completion((drivingTime + travelTimePadding)  <= timeInterval)
         })
     }
@@ -97,7 +101,7 @@ struct TravelTimes {
     let publicTransportTime: TimeInterval?
 
     func getShortestTravelTime() -> TimeInterval {
-        let driveTimePadding: Double = RemoteConfigKeys.travelTimePaddingMins.value * 60 
+        let driveTimePadding: Double = TravelTimesProvider.travelTimePadding
         let driveTime = drivingTime ?? (Double.greatestFiniteMagnitude - driveTimePadding)
         return min(walkingTime ?? Double.greatestFiniteMagnitude, driveTime + driveTimePadding )
     }

--- a/Prox/Prox/Models/Event.swift
+++ b/Prox/Prox/Models/Event.swift
@@ -31,6 +31,26 @@ class Event {
         return RemoteConfigKeys.eventAboutToEndIntervalMins.value * 60
     }()
 
+    private lazy var eventAboutToStartCardString: String = {
+        return self.formatEventString(string: RemoteConfigKeys.eventAboutToStartCardString.value)
+    }()
+
+    private lazy var eventAboutToEndCardString: String = {
+        return self.formatEventString(string: RemoteConfigKeys.eventAboutToEndCardString.value)
+    }()
+
+    private lazy var upcomingEventCardString: String =  {
+        return self.formatEventString(string: RemoteConfigKeys.upcomingEventCardString.value)
+    }()
+
+    private lazy var ongoingEventCardString: String = {
+        return self.formatEventString(string: RemoteConfigKeys.ongoingEventCardString.value)
+    }()
+
+    private lazy var endingEventCardString: String = {
+        return self.formatEventString(string: RemoteConfigKeys.endingEventCardString.value)
+    }()
+
     var notificationString: String? {
         let now = Date()
         if isUpcomingEvent(currentTime: now) {
@@ -51,19 +71,19 @@ class Event {
     var placeDisplayString: String? {
         let now = Date()
         if isAboutToStart(currentTime: now) {
-            return formatEventString(string: RemoteConfigKeys.eventAboutToStartCardString.value)
+            return eventAboutToStartCardString
         }
 
         if isAboutToEnd(currentTime: now) {
-            return formatEventString(string: RemoteConfigKeys.eventAboutToEndCardString.value)
+            return eventAboutToEndCardString
         }
 
         if isUpcomingEvent(currentTime: now) {
-            return formatEventString(string: RemoteConfigKeys.upcomingEventCardString.value)
+            return upcomingEventCardString
         }
 
         if isOngoingEvent(currentTime: now) {
-            return formatEventString(string: RemoteConfigKeys.ongoingEventCardString.value)
+            return ongoingEventCardString
         }
 
         if isEndingEvent(currentTime: now) {
@@ -161,7 +181,7 @@ class Event {
     }
 
     func arrivalByTime() -> Date {
-        let eventEndTimeArrivalInterval = RemoteConfigKeys.minTimeFromEndOfEventForNotificationMins.value * 60
+        let eventEndTimeArrivalInterval = Event.minTimeFromEndOfEventForNotificationMins
         let arrivalByTime: Date
         if let endTime = self.endTime {
             arrivalByTime = endTime - eventEndTimeArrivalInterval

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -429,6 +429,9 @@ extension PlaceCarouselViewController: PlaceDataSource {
             }
         } else {
             placesProvider.place(withKey: placeKey, forEventWithKey: eventKey) { place in
+                if let place = place {
+                    self.places.append(place)
+                }
                 callback(place)
             }
         }

--- a/Prox/Prox/Utilities/EventNotificationsManager.swift
+++ b/Prox/Prox/Utilities/EventNotificationsManager.swift
@@ -14,23 +14,16 @@ let notificationEventIDKey = "eventID"
 fileprivate typealias EventID = String
 
 class EventNotificationsManager {
-    // caches events by their start time by place
-    fileprivate lazy var sentNotifications: Set<EventID> = {
-        var cache = Set<EventID>()
-        guard let savedNotifications = UserDefaults.standard.dictionary(forKey: sentNotificationDictKey) as? [String: [EventID]] else {
-            return cache
+
+    fileprivate var sentNotifications: Set<String> {
+        get {
+            return Set<String>(UserDefaults.standard.array(forKey: sentNotificationDictKey) as? [String] ?? [])
         }
-        for (dateString, eventIDs) in savedNotifications {
-            if let timestamp = TimeInterval(dateString) {
-                let date = Date(timeIntervalSinceReferenceDate: timestamp)
-                if Calendar.current.isDateInToday(date) {
-                    let newIdsSet = Set<EventID>(eventIDs)
-                    cache.formUnion(newIdsSet)
-                }
-            }
+
+        set {
+            UserDefaults.standard.set(Array(newValue), forKey: sentNotificationDictKey)
         }
-        return cache
-    }()
+    }
 
     fileprivate var shouldFetchEvents: Bool {
         guard let eventFetchStartTime = eventFetchStartTime else {
@@ -79,7 +72,6 @@ class EventNotificationsManager {
     }
 
     func persistNotificationCache() {
-        UserDefaults.standard.set([String(Date().timeIntervalSinceReferenceDate): Array(sentNotifications)], forKey: sentNotificationDictKey)
         UserDefaults.standard.synchronize()
     }
 
@@ -202,6 +194,8 @@ class EventNotificationsManager {
     }
 
     fileprivate func markAsSent(event: Event) {
-        sentNotifications.insert(event.id)
+        var sent = sentNotifications
+        sent.insert(event.id)
+        sentNotifications = sent
     }
 }


### PR DESCRIPTION
Ostensibly this patch
- Adds places with events that are not in the places array on notification response to the places array so that it registers with the place counter on the detail screen and appears in the carousel

However I also found a couple of other things that I addressed
- Moved references to some of the remote config parameters to lazy vars so that they are not so noisy
- replaced notification cache with something simpler to ensure that it works properly. The cache was still not working well, sometimes notifiying about an event several times. It may grow very large over time, but at that point we can move the cache to the DB and not worry about having this sort of stuff in UserDefaults