### PR TITLE
Move PlacesDataSource impl to PlacesProvider

### DIFF
--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		7B561BB31DABD5C90096D8BC /* PlaceCarouselHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B561BB21DABD5C90096D8BC /* PlaceCarouselHeaderView.swift */; };
 		7B561BBA1DAC02B90096D8BC /* hilton_location.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 7B561BB91DAC02B90096D8BC /* hilton_location.gpx */; };
 		7B699A9E1DEDD635004A671B /* InAppNotificationToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B699A9D1DEDD635004A671B /* InAppNotificationToast.swift */; };
-		7B8651901DBF8544002A666A /* PlaceCarouselViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B86518F1DBF8544002A666A /* PlaceCarouselViewControllerTests.swift */; };
+		7B8651901DBF8544002A666A /* PlacesProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B86518F1DBF8544002A666A /* PlacesProviderTests.swift */; };
 		7B8651921DBFAF19002A666A /* PlaceUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8651911DBFAF19002A666A /* PlaceUtilities.swift */; };
 		7B8651941DBFAFA8002A666A /* PlaceUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8651931DBFAFA8002A666A /* PlaceUtilitiesTests.swift */; };
 		7B9D15C61DC0D2E70051B760 /* OpenInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9D15C51DC0D2E70051B760 /* OpenInHelper.swift */; };
@@ -163,7 +163,7 @@
 		7B561BB21DABD5C90096D8BC /* PlaceCarouselHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PlaceCarouselHeaderView.swift; path = PlaceCarousel/PlaceCarouselHeaderView.swift; sourceTree = "<group>"; };
 		7B561BB91DAC02B90096D8BC /* hilton_location.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = hilton_location.gpx; sourceTree = "<group>"; };
 		7B699A9D1DEDD635004A671B /* InAppNotificationToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppNotificationToast.swift; sourceTree = "<group>"; };
-		7B86518F1DBF8544002A666A /* PlaceCarouselViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceCarouselViewControllerTests.swift; sourceTree = "<group>"; };
+		7B86518F1DBF8544002A666A /* PlacesProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlacesProviderTests.swift; sourceTree = "<group>"; };
 		7B8651911DBFAF19002A666A /* PlaceUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceUtilities.swift; sourceTree = "<group>"; };
 		7B8651931DBFAFA8002A666A /* PlaceUtilitiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceUtilitiesTests.swift; sourceTree = "<group>"; };
 		7B9D15C51DC0D2E70051B760 /* OpenInHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenInHelper.swift; sourceTree = "<group>"; };
@@ -319,7 +319,7 @@
 				7B29E7D71DA3EC360099AF38 /* ProxTests.swift */,
 				7B29E7D91DA3EC360099AF38 /* Info.plist */,
 				7B5095801DB65FD4007C54F0 /* TravelTimesTests.swift */,
-				7B86518F1DBF8544002A666A /* PlaceCarouselViewControllerTests.swift */,
+				7B86518F1DBF8544002A666A /* PlacesProviderTests.swift */,
 				7B8651931DBFAFA8002A666A /* PlaceUtilitiesTests.swift */,
 				E6101A951DDA481800D05B74 /* CategoriesUtilTests.swift */,
 				7B2EF5861DDF4D7200695515 /* TimeIntervalTests.swift */,
@@ -873,7 +873,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B8651901DBF8544002A666A /* PlaceCarouselViewControllerTests.swift in Sources */,
+				7B8651901DBF8544002A666A /* PlacesProviderTests.swift in Sources */,
 				E6101A961DDA481800D05B74 /* CategoriesUtilTests.swift in Sources */,
 				7B5095811DB65FD4007C54F0 /* TravelTimesTests.swift in Sources */,
 				7B8651941DBFAFA8002A666A /* PlaceUtilitiesTests.swift in Sources */,

--- a/Prox/Prox/Data/FirebasePlacesDatabase.swift
+++ b/Prox/Prox/Data/FirebasePlacesDatabase.swift
@@ -26,23 +26,9 @@ class FirebasePlacesDatabase: PlacesDatabase {
     }
 
     /*
-     * Queries GeoFire to get the place keys around the given location and then queries Firebase to
-     * get the place details for the place keys.
-     */
-    func getPlaces(forLocation location: CLLocation, withRadius radius: Double) -> Future<[DatabaseResult<Place>]> {
-        let queue = DispatchQueue.global(qos: .userInitiated)
-        let places = getPlaceKeys(aroundPoint: location, withRadius: radius).andThen(upon: queue) { (placeKeyToLoc) -> Future<[DatabaseResult<Place>]> in
-            // TODO: limit the number of place details we look up. X closest places?
-            // TODO: These should be ordered by display order
-            return self.getPlaceDetails(fromKeys: Array(placeKeyToLoc.keys)).allFilled()
-        }
-        return places
-    }
-
-    /*
      * Queries GeoFire to find keys that represent locations around the given point.
      */
-    private func getPlaceKeys(aroundPoint location: CLLocation, withRadius radius: Double) -> Deferred<[String:CLLocation]> {
+    func getPlaceKeys(aroundPoint location: CLLocation, withRadius radius: Double) -> Deferred<[String:CLLocation]> {
         let deferred = Deferred<[String:CLLocation]>()
         var placeKeyToLoc = [String:CLLocation]()
 
@@ -71,7 +57,7 @@ class FirebasePlacesDatabase: PlacesDatabase {
     /*
      * Queries Firebase to find the place details from the given keys.
      */
-    private func getPlaceDetails(fromKeys placeKeys: [String]) -> [Deferred<DatabaseResult<Place>>] {
+    func getPlaceDetails(fromKeys placeKeys: [String]) -> [Deferred<DatabaseResult<Place>>] {
         let placeDetails = placeKeys.map { placeKey -> Deferred<DatabaseResult<Place>> in
             queryChildPlaceDetails(by: placeKey)
         }

--- a/Prox/Prox/Data/PlacesController.swift
+++ b/Prox/Prox/Data/PlacesController.swift
@@ -62,6 +62,11 @@ class PlacesProvider {
     convenience init(places: [Place]) {
         self.init()
         self.displayedPlaces = places
+        var placesMap = [String: Int]()
+        for (index, place) in displayedPlaces.enumerated() {
+            placesMap[place.id] = index
+        }
+        self.placeKeyMap = placesMap
     }
 
     func place(forKey key: String, callback: @escaping (Place?) -> ()) {

--- a/Prox/Prox/Data/PlacesController.swift
+++ b/Prox/Prox/Data/PlacesController.swift
@@ -46,6 +46,15 @@ class PlacesProvider {
 
     fileprivate let placesLock = NSLock()
 
+    init() {
+
+    }
+
+    convenience init(places: [Place]) {
+        self.init()
+        self.places = places
+    }
+
     func place(forKey key: String, callback: @escaping (Place?) -> ()) {
         database.getPlace(forKey: key).upon { callback($0.successResult() )}
     }

--- a/Prox/Prox/Data/PlacesDatabase.swift
+++ b/Prox/Prox/Data/PlacesDatabase.swift
@@ -10,6 +10,7 @@ import CoreLocation
  * A listing of all the places we'd want to show a user.
  */
 protocol PlacesDatabase {
-    func getPlaces(forLocation location: CLLocation, withRadius: Double) -> Future<[DatabaseResult<Place>]>
+    func getPlaceKeys(aroundPoint location: CLLocation, withRadius radius: Double) -> Deferred<[String:CLLocation]>
+    func getPlaceDetails(fromKeys placeKeys: [String]) -> [Deferred<DatabaseResult<Place>>]
     func getPlace(forKey key: String) -> Deferred<DatabaseResult<Place>>
 }

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -454,8 +454,10 @@ extension PlaceCarouselViewController: PlacesProviderDelegate {
         // TODO: how do we make sure the user wasn't interacting?
         headerView.numberOfPlacesLabel.text = "\(places.count) place" + (places.count != 1 ? "s" : "")
         placeCarousel.refresh()
-
-        (self.presentedViewController as? PlaceDetailViewController)?.placesUpdated()
+        // calling async to prevent deadlock inside placesUpdated
+        DispatchQueue.main.async {
+            (self.presentedViewController as? PlaceDetailViewController)?.placesUpdated()
+        }
     }
 
     func placesProviderDidTimeout(_ controller: PlacesProvider) {

--- a/Prox/ProxTests/PlacesProviderTests.swift
+++ b/Prox/ProxTests/PlacesProviderTests.swift
@@ -8,13 +8,10 @@ import MapKit
 
 @testable import Prox
 
-class PlaceCarouselViewControllerTests: XCTestCase {
-
-    var placeCarouselVC: PlaceCarouselViewController!
+class PlacesProviderTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        placeCarouselVC = PlaceCarouselViewController()
     }
     
     override func tearDown() {
@@ -37,22 +34,23 @@ class PlaceCarouselViewControllerTests: XCTestCase {
 }
 
 // PlaceDataSource implementation tests
-extension PlaceCarouselViewControllerTests {
+extension PlacesProviderTests {
 
     func testPlaceDataSourceReturnsCorrectNumberOfPlaces() {
         let places = placesList(number: 4)
-        placeCarouselVC.places = places
 
-        XCTAssertEqual(placeCarouselVC.numberOfPlaces(), places.count)
+        let placeDataSource = PlacesProvider(places: places)
+
+        XCTAssertEqual(placeDataSource.numberOfPlaces(), places.count)
     }
 
     func testPlaceDataSourceReturnsCorrectPlaceForIndex() {
         let places = placesList(number: 4)
-        placeCarouselVC.places = places
+        let placeDataSource = PlacesProvider(places: places)
 
         let requestedIndex = 2
 
-        let thirdPlace = try? placeCarouselVC.place(forIndex: requestedIndex)
+        let thirdPlace = try? placeDataSource.place(forIndex: requestedIndex)
         XCTAssertNotNil(thirdPlace)
 
         XCTAssertEqual(thirdPlace!.id, "\(requestedIndex)")
@@ -60,22 +58,22 @@ extension PlaceCarouselViewControllerTests {
 
     func testPlaceDataSourceThrowsErrorOnOutOfBoundsIndex() {
         let places = placesList(number: 4)
-        placeCarouselVC.places = places
+        let placeDataSource = PlacesProvider(places: places)
 
-        XCTAssertThrowsError(try placeCarouselVC.place(forIndex: 4))
-        XCTAssertThrowsError(try placeCarouselVC.place(forIndex: -1))
+        XCTAssertThrowsError(try placeDataSource.place(forIndex: 4))
+        XCTAssertThrowsError(try placeDataSource.place(forIndex: -1))
     }
 
     func testPlaceDataSourceReturnsCorrectNextPlace() {
         let places = placesList(number: 4)
-        placeCarouselVC.places = places
+        let placeDataSource = PlacesProvider(places: places)
 
         // test with known next place
         var requestedIndex = 0
         var currentPlace = places[requestedIndex]
         // should be 1
         XCTAssertEqual(currentPlace.id, "\(requestedIndex)")
-        var nextPlace = placeCarouselVC.nextPlace(forPlace: currentPlace)
+        var nextPlace = placeDataSource.nextPlace(forPlace: currentPlace)
         // should be 2
         XCTAssertNotNil(nextPlace)
         XCTAssertEqual(nextPlace!.id, "\(requestedIndex + 1)")
@@ -83,20 +81,20 @@ extension PlaceCarouselViewControllerTests {
         // test with known no next place
         requestedIndex = places.endIndex - 1
         currentPlace = places[requestedIndex]
-        nextPlace = placeCarouselVC.nextPlace(forPlace: currentPlace)
+        nextPlace = placeDataSource.nextPlace(forPlace: currentPlace)
         XCTAssertNil(nextPlace)
     }
 
     func testPlaceDataSourceReturnsCorrectPreviousPlace() {
         let places = placesList(number: 4)
-        placeCarouselVC.places = places
+        let placeDataSource = PlacesProvider(places: places)
 
         // test with known next place
         var requestedIndex = 3
         var currentPlace = places[requestedIndex]
         // should be 4
         XCTAssertEqual(currentPlace.id, "\(requestedIndex)")
-        var previousPlace = placeCarouselVC.previousPlace(forPlace: currentPlace)
+        var previousPlace = placeDataSource.previousPlace(forPlace: currentPlace)
         XCTAssertNotNil(previousPlace)
         // should be 3
         XCTAssertEqual(previousPlace!.id, "\(requestedIndex - 1)")
@@ -104,7 +102,7 @@ extension PlaceCarouselViewControllerTests {
         // test with known no next place
         requestedIndex = places.startIndex
         currentPlace = places[requestedIndex]
-        previousPlace = placeCarouselVC.previousPlace(forPlace: currentPlace)
+        previousPlace = placeDataSource.previousPlace(forPlace: currentPlace)
         XCTAssertNil(previousPlace)
     }
 


### PR DESCRIPTION
In Hawaii I wondered whether we could make fetching faster and less data intensive if the `PlacesProvider` was also the `PlacesDataSource` that the rest of the app used. We could then check our geofire query results and only fetch those places that we were currently missing rather than fetching all places every time. This would also mean that if no new places were required then no fetches would be passed.

It's a thought experiment, but could be combined with the caching to provide an improvement to our place loading times.