### PR TITLE
Remove unused sessions, correct loading and permissions

### DIFF
--- a/Prox/Prox/AppDelegate.swift
+++ b/Prox/Prox/AppDelegate.swift
@@ -29,10 +29,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
-        Analytics.startAppSession()
-        // Start session measuring Loading duration
-        Analytics.startSession(sessionName: AppState.State.loading.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
-
         setupFirebase()
         setupRemoteConfig()
         BuddyBuildSDK.setup()
@@ -133,6 +129,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        Analytics.startAppSession()
+        if (AppState.getState() == AppState.State.initial || AppState.getState() == AppState.State.permissions) {
+            AppState.enterLoading()
+        }
         placeCarouselViewController?.locationMonitor.refreshLocation()
     }
 
@@ -140,7 +140,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         placeCarouselViewController?.locationMonitor.cancelTimeAtLocationTimer()
         eventsNotificationsManager?.persistNotificationCache()
-        AppState.exiting()
     }
 
     func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {

--- a/Prox/Prox/Models/AppState.swift
+++ b/Prox/Prox/Models/AppState.swift
@@ -23,20 +23,6 @@ class AppState {
         updateSessionState(newState: State.loading)
     }
 
-    static func requestPermissions() {
-        if (state == State.loading) {
-            // Stop loading session if handling permissions
-            let params: [String: Any] = [AnalyticsEvent.PARAM_ACTION: AnalyticsEvent.PERMISSIONS]
-            Analytics.endSession(sessionName: State.loading.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: params)
-            state = State.permissions
-            print("[debug] endsession because permissions. New state: \(state)")
-        } else {
-            let params : [String: Any] = [AnalyticsEvent.SESSION_STATE: state.rawValue]
-            Analytics.logEvent(event: AnalyticsEvent.PERMISSIONS, params: params)
-            print("[debug] permissions event. Current state \(state)")
-        }
-    }
-
     static func enterBackground() {
         print("[debug] entering background from: " + state.rawValue)
         preBackgroundState = state

--- a/Prox/Prox/Models/AppState.swift
+++ b/Prox/Prox/Models/AppState.swift
@@ -6,17 +6,35 @@ import Foundation
 
 class AppState {
     enum State: String {
-        case loading, details, carousel, background, exiting, unknown
+        case initial, loading, permissions, details, carousel, background, unknown
     }
 
     private static var cardVisits = Set<Int>()
 
     // Initial app state
-    private static var state = State.loading
+    private static var state = State.initial
     private static var preBackgroundState: State?
 
     static func getState() -> State {
         return state
+    }
+
+    static func enterLoading() {
+        updateSessionState(newState: State.loading)
+    }
+
+    static func requestPermissions() {
+        if (state == State.loading) {
+            // Stop loading session if handling permissions
+            let params: [String: Any] = [AnalyticsEvent.PARAM_ACTION: AnalyticsEvent.PERMISSIONS]
+            Analytics.endSession(sessionName: State.loading.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: params)
+            state = State.permissions
+            print("[debug] endsession because permissions. New state: \(state)")
+        } else {
+            let params : [String: Any] = [AnalyticsEvent.SESSION_STATE: state.rawValue]
+            Analytics.logEvent(event: AnalyticsEvent.PERMISSIONS, params: params)
+            print("[debug] permissions event. Current state \(state)")
+        }
     }
 
     static func enterBackground() {
@@ -40,12 +58,7 @@ class AppState {
         updateSessionState(newState: State.details)
     }
 
-    static func exiting() {
-        updateSessionState(newState: State.exiting)
-    }
-
     private static func updateSessionState(newState: State) {
-        print("[debug] Previous state: " + state.rawValue)
         var params: [String: Any] = [:]
         if (cardVisits.count > 0) {
             params[AnalyticsEvent.NUM_CARDS] = cardVisits.count
@@ -55,14 +68,16 @@ class AppState {
             // Try to close a Detail card session, it's okay if it doesn't exist
             Analytics.endSession(sessionName: AnalyticsEvent.DETAILS_CARD_SESSION_DURATION, params: [:])
         }
-        Analytics.endSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: params)
+
+        if (state != State.initial) {
+            print("[debug] Previous state: " + state.rawValue)
+            Analytics.endSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: params)
+        }
 
         print("[debug] New state: " + newState.rawValue)
         state = newState
 
-        if (state != State.exiting) {
-            Analytics.startSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
-        }
+        Analytics.startSession(sessionName: state.rawValue + AnalyticsEvent.SESSION_SUFFIX, params: [:])
     }
 
     static func trackCardVisit(cardPos: Int) {

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -148,7 +148,6 @@ class PlaceCarouselViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
 
         if let backgroundImage = UIImage(named: "map_background") {
@@ -303,6 +302,7 @@ class PlaceCarouselViewController: UIViewController {
         alertController.addAction(settingsAction)
         alertController.addAction(quitAction)
 
+        AppState.requestPermissions()
         self.present(alertController, animated: true)
     }
 

--- a/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarouselViewController.swift
@@ -302,7 +302,7 @@ class PlaceCarouselViewController: UIViewController {
         alertController.addAction(settingsAction)
         alertController.addAction(quitAction)
 
-        AppState.requestPermissions()
+        Analytics.logEvent(event: AnalyticsEvent.LOCATION_REPROMPT, params: [:])
         self.present(alertController, animated: true)
     }
 

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -17,8 +17,10 @@ class Analytics {
             print("No Flurry key! Not collecting analytics.")
             return
         }
+
+        // Deprecated, but no Swift alternative right now
+        Flurry.setSessionContinueSeconds(30)
         Flurry.startSession(flurryKey)
-        Flurry.logEvent(AnalyticsEvent.APP_INIT)
     }
 
     static func logEvent(event: String, params: [String: Any]) {
@@ -35,11 +37,8 @@ class Analytics {
 }
 
 public struct AnalyticsEvent {
-    static let APP_INIT = "app_init";
-
     static let SESSION_SUFFIX = "_session_duration"
     static let DETAILS_CARD_SESSION_DURATION   = "details_card" + SESSION_SUFFIX
-
 
     // Place Details
     static let YELP               = "yelp_link"
@@ -61,10 +60,12 @@ public struct AnalyticsEvent {
     static let PARAM_ACTION       = "action"
     static let NUM_CARDS          = "num_cards"
     static let CARD_INDEX         = "card_index"
+    static let SESSION_STATE      = "session_state"
 
     // Events
     static let EVENT_BANNER_LINK  = "event_banner_link"
     static let EVENT_NOTIFICATION = "event_notification"
+    static let PERMISSIONS        = "permissions"
     static let BACKGROUND         = "notified_background" // Event was notified while app was in the background
     static let FOREGROUND         = "notified_foreground" // Event was notified while the app is open
     static let CLICKED            = "notification_clicked" // Clicked on the notification

--- a/Prox/Prox/Utilities/AnalyticsUtilities.swift
+++ b/Prox/Prox/Utilities/AnalyticsUtilities.swift
@@ -18,12 +18,12 @@ class Analytics {
             return
         }
 
-        // Deprecated, but no Swift alternative right now
-        Flurry.setSessionContinueSeconds(30)
-        Flurry.startSession(flurryKey)
+        let builder = FlurrySessionBuilder().withSessionContinueSeconds(30)
+        Flurry.startSession(flurryKey, with: builder)
     }
 
     static func logEvent(event: String, params: [String: Any]) {
+        print("[debug] Analytics event: \(event)")
         Flurry.logEvent(event, withParameters: params)
     }
 
@@ -65,8 +65,9 @@ public struct AnalyticsEvent {
     // Events
     static let EVENT_BANNER_LINK  = "event_banner_link"
     static let EVENT_NOTIFICATION = "event_notification"
-    static let PERMISSIONS        = "permissions"
     static let BACKGROUND         = "notified_background" // Event was notified while app was in the background
     static let FOREGROUND         = "notified_foreground" // Event was notified while the app is open
     static let CLICKED            = "notification_clicked" // Clicked on the notification
+    static let NO_PLACES_DIALOG   = "no_places_dialog" // No places nearby dialog
+    static let LOCATION_REPROMPT  = "location_reprompt" // Dialog re-prompt for users who have denied the location permission
 }

--- a/Prox/Prox/Widgets/LoadingOverlayView.swift
+++ b/Prox/Prox/Widgets/LoadingOverlayView.swift
@@ -105,6 +105,8 @@ class LoadingOverlayView: UIView {
             self.searchAgainButton.alpha = 1
             self.layoutIfNeeded()
         }, completion: { _ in })
+
+        Analytics.logEvent(event: AnalyticsEvent.NO_PLACES_DIALOG, params: [:])
     }
 
     func fadeOutMessaging() {


### PR DESCRIPTION
This fixes the biggest problem with session measuring where we were collecting data even if the app isn't visible. This shouldn't be a problem (while notifications are disabled) but this fixes differentiating between background sessions (testing with the Xcode "background fetch" scheme) and user-initiated sessions.

This also adds measurements for permissions, and also moved the analytics collection into user-initiated actions rather than including background fetches.

(I initially thought that this would require setting listeners for viewDidLoad but I had misconceptions about how granular iOS view management was, so that ended up not being relevant.)