### PR TITLE
No issue: Logging cleanup

### DIFF
--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7BD5CC8A1DB0EB7400BCF50D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7BD5CC881DB0EB7400BCF50D /* GoogleService-Info.plist */; };
 		7BD5CC8B1DB0EB7400BCF50D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7BD5CC881DB0EB7400BCF50D /* GoogleService-Info.plist */; };
 		7C79B23D6CD1B1AC5A860E9E /* Pods_ProxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 032E1A5B4FC2DB4F395E29E9 /* Pods_ProxTests.framework */; };
+		D3656D981E4A7D0F00040448 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3656D971E4A7D0F00040448 /* Logger.swift */; };
 		D3C815681E4542E30066A97B /* PlaceProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C815671E4542E30066A97B /* PlaceProviders.swift */; };
 		E60A42711DF28E01008BE74D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A42701DF28E01008BE74D /* URL.swift */; };
 		E60A42771DF29127008BE74D /* URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A42761DF29127008BE74D /* URLTests.swift */; };
@@ -205,6 +206,7 @@
 		BD2188137E599F03500C7FBD /* Pods-ProxUITests.enterprise kona.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.enterprise kona.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.enterprise kona.xcconfig"; sourceTree = "<group>"; };
 		CBFE1FD0629546576538F51D /* Pods-ProxTests.chicago.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxTests.chicago.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxTests/Pods-ProxTests.chicago.xcconfig"; sourceTree = "<group>"; };
 		CE887CEB1CF45A1D782FC885 /* Pods-Prox.current location.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Prox.current location.xcconfig"; path = "../Pods/Target Support Files/Pods-Prox/Pods-Prox.current location.xcconfig"; sourceTree = "<group>"; };
+		D3656D971E4A7D0F00040448 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		D3C815671E4542E30066A97B /* PlaceProviders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceProviders.swift; sourceTree = "<group>"; };
 		D3DA777E1DC2776C009C114E /* BuddyBuildSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BuddyBuildSDK.framework; path = ../Pods/BuddyBuildSDK/BuddyBuildSDK.framework; sourceTree = "<group>"; };
 		D3DA77821DC289A4009C114E /* Prox-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Prox-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 				7BA05BEA1DD4D602009AC121 /* EventNotificationsManager.swift */,
 				7B5095711DB5352E007C54F0 /* Fonts.swift */,
 				7B0ECE471DD6145500ABBD72 /* LocationMonitor.swift */,
+				D3656D971E4A7D0F00040448 /* Logger.swift */,
 				7B9D15C51DC0D2E70051B760 /* OpenInHelper.swift */,
 				7B8651911DBFAF19002A666A /* PlaceUtilities.swift */,
 				7B5095771DB64E76007C54F0 /* TravelTimesProvider.swift */,
@@ -860,6 +863,7 @@
 				7BA05BE51DD4CCB1009AC121 /* Event.swift in Sources */,
 				7BD5CC801DAFF07E00BCF50D /* GFGeoHashQuery.m in Sources */,
 				E618319B1DE0C57700D1810F /* PlaceDetailsTravelTimesView.swift in Sources */,
+				D3656D981E4A7D0F00040448 /* Logger.swift in Sources */,
 				7B1C657B1DDCA9A90047559C /* FirebaseEventsDatabase.swift in Sources */,
 				E681E7581DE3562200902CDA /* Animatable.swift in Sources */,
 				7B9DA1571DBE6EE300A68C82 /* PlaceCarouselViewController.swift in Sources */,

--- a/Prox/Prox/Data/FirebaseEventsDatabase.swift
+++ b/Prox/Prox/Data/FirebaseEventsDatabase.swift
@@ -114,7 +114,7 @@ class FirebaseEventsDatabase: EventsDatabase {
 
         // Handle query completion.
         circleQuery.observeReady {
-            print("lol geofire query has completed")
+            log.debug("geofire events query complete: found \(eventKeyToLoc.count) events")
             circleQuery.removeAllObservers()
             deferred.fill(with: eventKeyToLoc)
         }

--- a/Prox/Prox/Data/FirebasePlacesDatabase.swift
+++ b/Prox/Prox/Data/FirebasePlacesDatabase.swift
@@ -46,7 +46,7 @@ class FirebasePlacesDatabase: PlacesDatabase {
 
         // Handle query completion.
         circleQuery.observeReady {
-            print("lol geofire query has completed: found \(placeKeyToLoc.count) places")
+            log.debug("geofire places query complete: found \(placeKeyToLoc.count) places")
             circleQuery.removeAllObservers()
             deferred.fill(with: placeKeyToLoc)
         }

--- a/Prox/Prox/Models/Event.swift
+++ b/Prox/Prox/Models/Event.swift
@@ -111,7 +111,7 @@ class Event {
             let lngStr = coords["lng"], let lng = Double(lngStr),
             let description = value["description"] as? String,
             let localStartTimeString = value["localStartTime"] as? String else {
-                print("lol dropping event: missing data, id, placeId, description, start time \(value)")
+                log.debug("dropping event: missing data, id, placeId, description, start time \(value)")
                 return nil
         }
 

--- a/Prox/Prox/Models/Place.swift
+++ b/Prox/Prox/Models/Place.swift
@@ -69,7 +69,7 @@ class Place: Hashable {
 
     convenience init?(fromFirebaseSnapshot details: FIRDataSnapshot) {
         guard let yelpDict = details.childSnapshot(forPath: YELP_PATH).value as? [String: Any] else {
-            print("lol place has no Yelp content: \(details.key)")
+            log.warn("place has no Yelp content: \(details.key)")
             return nil
         }
 
@@ -91,7 +91,7 @@ class Place: Hashable {
         guard let id = compositeProvider.id,
               let name = compositeProvider.name,
               let latLong = compositeProvider.latLong else {
-            print("lol dropping place: missing data, id, name, or coords")
+            log.warn("dropping place: missing data, id, name, or coords")
             return nil
         }
 
@@ -287,20 +287,20 @@ struct OpenHours {
         // it's closed for the day and we're supposed to omit it anyway.
         for dayFromServer in hoursDict.keys {
             guard let day = DayOfWeek(rawValue: dayFromServer) else {
-                print("lol unknown day of week from server: \(dayFromServer)")
+                log.error("unknown day of week from server: \(dayFromServer)")
                 return nil
             }
 
             let hoursArr = hoursDict[dayFromServer]! // force unwrap: we're iterating over the keys.
             let hoursForDay: [OpenPeriodDateComponents] = hoursArr.flatMap { interval in
                 guard interval.count == 2 else {
-                    print("lol last opening interval unexpectedly has \(interval.count) entries")
+                    log.error("last opening interval unexpectedly has \(interval.count) entries")
                     return nil
                 }
 
                 guard let openTime = getTimeComponents(fromServerStr: interval[0]),
                         let closeTime = getTimeComponents(fromServerStr: interval[1]) else {
-                    print("lol unable to convert date str, \(interval[0]) & \(interval[1]), to Date")
+                    log.error("unable to convert date str, \(interval[0]) & \(interval[1]), to Date")
                     return nil
                 }
                 return(openTime: openTime, closeTime: closeTime)
@@ -321,14 +321,14 @@ struct OpenHours {
 
     private func getOpeningTimes(forDate date: Date) -> [OpenPeriodDates]? {
         guard let openTimesForDay = hours[DayOfWeek.forDate(date)] else {
-            NSLog("There are no open time for \(DayOfWeek.forDate(date)) in \(hours)")
+            log.debug("There are no open time for \(DayOfWeek.forDate(date)) in \(hours)")
             return nil
         }
 
         let allOpeningTimes: [OpenPeriodDates] = openTimesForDay.flatMap { times in
             guard let openingTime = getDate(forTime: times.openTime, onDate: date),
                 var closingTime = getDate(forTime: times.closeTime, onDate: date) else {
-                    NSLog("No opening times opening: \(getDate(forTime: times.openTime, onDate: date)), closing: \(getDate(forTime: times.closeTime, onDate: date))")
+                    log.debug("No opening times opening: \(getDate(forTime: times.openTime, onDate: date)), closing: \(getDate(forTime: times.closeTime, onDate: date))")
                     return nil
             }
 

--- a/Prox/Prox/Models/PlaceProviders.swift
+++ b/Prox/Prox/Models/PlaceProviders.swift
@@ -152,7 +152,7 @@ extension SinglePlaceProvider {
         var ids = [String]()
         for category in value {
             guard let name = category["text"], let id = category["id"] else {
-                print("lol unable to retrieve category from firebase data for place")
+                log.warn("unable to retrieve category from firebase data for place")
                 continue
             }
 

--- a/Prox/Prox/PlaceCarousel/PlaceCarousel.swift
+++ b/Prox/Prox/PlaceCarousel/PlaceCarousel.swift
@@ -122,7 +122,7 @@ extension PlaceCarousel: UICollectionViewDataSource {
         cell.placeImage.image = UIImage(named: "carousel_image_loading")
 
         guard let url = place.photoURLs.first else {
-            print("lol unable to create URL from photo url")
+            log.error("place has no photo URLs: \(place.id)")
             return
         }
 

--- a/Prox/Prox/PlaceDetails/PlaceDetailsCardViewController.swift
+++ b/Prox/Prox/PlaceDetails/PlaceDetailsCardViewController.swift
@@ -159,7 +159,7 @@ class PlaceDetailsCardViewController: UIViewController {
     @objc private func openPlaceURL(gestureRecognizer: UITapGestureRecognizer) {
         guard let url = place.url else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open web address")
+            log.error("unable to open web address")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.WEBSITE, params: [:])
         }
@@ -168,7 +168,7 @@ class PlaceDetailsCardViewController: UIViewController {
     @objc private func openYelpReview(gestureRecognizer: UITapGestureRecognizer) {
         guard let url = place.yelpProvider.url else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open yelp review")
+            log.error("unable to open yelp review")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.YELP, params: [:])
         }
@@ -177,7 +177,7 @@ class PlaceDetailsCardViewController: UIViewController {
     @objc private func openReadMoreYelpLink(gestureRecognizer: UITapGestureRecognizer) {
         guard let url = place.yelpProvider.url else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open yelp review")
+            log.error("unable to open yelp review")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.YELP_READ, params: [:])
         }
@@ -186,7 +186,7 @@ class PlaceDetailsCardViewController: UIViewController {
     @objc private func openTripAdvisorReview(gestureRecognizer: UITapGestureRecognizer) {
         guard let url = place.tripAdvisorProvider?.url else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open trip advisor review")
+            log.error("unable to open trip advisor review")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.TRIPADVISOR, params: [:])
         }
@@ -195,7 +195,7 @@ class PlaceDetailsCardViewController: UIViewController {
     @objc private func openReadMoreTripAdvisorLink(gestureRecgonizer: UITapGestureRecognizer) {
         guard let url = place.tripAdvisorProvider?.url else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open trip advisor review")
+            log.error("unable to open trip advisor review")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.TRIPADVISOR_READ, params: [:])
         }
@@ -207,7 +207,7 @@ class PlaceDetailsCardViewController: UIViewController {
         let transportType = transportString == "Walking" ? MKDirectionsTransportType.walking : MKDirectionsTransportType.automobile
 
         if !OpenInHelper.openRoute(fromLocation: location.coordinate, toPlace: place, by: transportType) {
-            print("lol unable to open travel directions")
+            log.error("unable to open travel directions")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.DIRECTIONS, params: [AnalyticsEvent.PARAM_ACTION: transportString])
         }
@@ -218,7 +218,7 @@ class PlaceDetailsCardViewController: UIViewController {
             let urlString = event.url,
             let url = URL(httpStringMaybeWithScheme: urlString) else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open web address")
+            log.error("unable to open web address")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.EVENT_BANNER_LINK, params: [AnalyticsEvent.PARAM_ACTION: AnalyticsEvent.CLICKED])
         }
@@ -227,7 +227,7 @@ class PlaceDetailsCardViewController: UIViewController {
     @objc private func openWikipediaURL(gestureRecognizer: UITapGestureRecognizer) {
         guard let url = place.wikipediaProvider?.url else { return }
         if !OpenInHelper.open(url: url) {
-            print("lol unable to open wikipedia review")
+            log.error("unable to open wikipedia review")
         } else {
             Analytics.logEvent(event: AnalyticsEvent.WIKIPEDIA_READ, params: [:])
         }

--- a/Prox/Prox/Utilities/CategoriesUtil.swift
+++ b/Prox/Prox/Utilities/CategoriesUtil.swift
@@ -40,7 +40,7 @@ struct CategoriesUtil {
         var hiddenCategories = Set<String>()
         for category in categories {
             guard let descendants = categoryToDescendantsMap[category] else {
-                print("lol unknown category, \(category) (from Firebase?). Ignoring")
+                log.warn("unknown category, \(category) (from Firebase?). Ignoring")
                 continue
             }
 

--- a/Prox/Prox/Utilities/LocationMonitor.swift
+++ b/Prox/Prox/Utilities/LocationMonitor.swift
@@ -191,7 +191,7 @@ extension LocationMonitor: CLLocationManagerDelegate {
             return
         }
 
-        NSLog("lol-location \(error.localizedDescription)")
+        log.error("location \(error.localizedDescription)")
         self.delegate?.locationMonitor(self, didFailInitialUpdateWithError: error)
     }
 
@@ -206,6 +206,6 @@ extension LocationMonitor: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
-        print("lol-location region monitoring failed \(error.localizedDescription)")
+        log.error("location region monitoring failed \(error.localizedDescription)")
     }
 }

--- a/Prox/Prox/Utilities/Logger.swift
+++ b/Prox/Prox/Utilities/Logger.swift
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+enum LoggerLevel: Int {
+    case debug
+    case info
+    case warn
+    case error
+}
+
+class Logger {
+    private let tag: String
+
+    var minPrintedLevel: LoggerLevel
+
+    /// Create a Logger instance that prints messages with the given tag.
+    /// Messages are filtered out if they are less than the given level.
+    init(tag: String, minPrintedLevel: LoggerLevel) {
+        self.tag = tag
+        self.minPrintedLevel = minPrintedLevel
+    }
+
+    /// Create a Logger instance that prints messages with the given tag.
+    /// Assigns the level based on the current build channel.
+    convenience init(tag: String) {
+        let minPrintedLevel: LoggerLevel
+        switch AppConstants.BuildChannel {
+        case .Debug:
+            minPrintedLevel = .debug
+        case .Release:
+            minPrintedLevel = .warn
+        case .CurrentLocation: fallthrough
+        case .MockLocation:
+            minPrintedLevel = .info
+        }
+
+        self.init(tag: tag, minPrintedLevel: minPrintedLevel)
+    }
+
+    func debug(_ message: Any?) {
+        log(message, level: .debug)
+    }
+
+    func info(_ message: Any?) {
+        log(message, level: .info)
+    }
+
+    func warn(_ message: Any?) {
+        log(message, level: .warn)
+    }
+
+    func error(_ message: Any?) {
+        log(message, level: .error)
+    }
+
+    private func log(_ message: Any?, level: LoggerLevel) {
+        guard level.rawValue >= self.minPrintedLevel.rawValue else { return }
+        NSLog("\(tag) [\(level)] \(message ?? "nil")")
+    }
+}
+
+/// The default Logger instance.
+let log = Logger(tag: "lol")

--- a/Prox/Prox/Utilities/PlaceUtilities.swift
+++ b/Prox/Prox/Utilities/PlaceUtilities.swift
@@ -66,13 +66,13 @@ struct PlaceUtilities {
 
             let shouldShowByCategory = CategoriesUtil.shouldShowPlace(byCategories: place.categories.ids)
             guard shouldShowByCategory else {
-                print("lol filtering out place, \(place.id), by category")
+                log.debug("filtering out place, \(place.id), by category")
                 return shouldShowByCategory
             }
 
             let shouldShowByRating = shouldShowPlaceByRatingAndReviewCount(place)
             guard shouldShowByRating  else {
-                print("lol filtering out place, \(place.id), by rating")
+                log.debug("filtering out place, \(place.id), by rating")
                 return shouldShowByRating
             }
 
@@ -83,7 +83,7 @@ struct PlaceUtilities {
     static func shouldShowPlaceByRatingAndReviewCount(_ place: Place) -> Bool {
         guard let rating = place.yelpProvider.rating,
                 let reviewCount = place.yelpProvider.totalReviewCount else {
-            print("lol missing rating or review count for place \(place.id)")
+            log.warn("missing rating or review count for place \(place.id)")
             return false
         }
 


### PR DESCRIPTION
Some simple changes to make our logging a bit less ad hoc. This allows us to
* use standard logging level for each message (debug/info/warn/error)
* filter levels based on the build
* not have to include the tag in each message
* create new `Logger` instances with different tags

I'm also not a fan of the current "lol" tag since it has no meaning, but we can fix that separately. This at least sets the foundation so we can change that default tag easily.