### PR TITLE
No issue: Generate LocalConfig.plist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ xcuserdata/
 Prox/Prox/GoogleService-Info.plist
 Prox/Prox/APIKeys.plist
 
+# Local config
+Prox/Prox/LocalConfig.plist
+
 ## Obj-C/Swift specific
 *.hmap
 *.ipa

--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		7C79B23D6CD1B1AC5A860E9E /* Pods_ProxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 032E1A5B4FC2DB4F395E29E9 /* Pods_ProxTests.framework */; };
 		D3656D981E4A7D0F00040448 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3656D971E4A7D0F00040448 /* Logger.swift */; };
 		D3C815681E4542E30066A97B /* PlaceProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C815671E4542E30066A97B /* PlaceProviders.swift */; };
+		D3E2B33A1E4BE7D10092882B /* LocalConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = D3E2B3391E4BE7D10092882B /* LocalConfig.plist */; };
 		E60A42711DF28E01008BE74D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A42701DF28E01008BE74D /* URL.swift */; };
 		E60A42771DF29127008BE74D /* URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A42761DF29127008BE74D /* URLTests.swift */; };
 		E6101A901DDA45CD00D05B74 /* Data.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E6101A8F1DDA45CD00D05B74 /* Data.bundle */; };
@@ -210,6 +211,7 @@
 		D3C815671E4542E30066A97B /* PlaceProviders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceProviders.swift; sourceTree = "<group>"; };
 		D3DA777E1DC2776C009C114E /* BuddyBuildSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BuddyBuildSDK.framework; path = ../Pods/BuddyBuildSDK/BuddyBuildSDK.framework; sourceTree = "<group>"; };
 		D3DA77821DC289A4009C114E /* Prox-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Prox-Bridging-Header.h"; sourceTree = "<group>"; };
+		D3E2B3391E4BE7D10092882B /* LocalConfig.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = LocalConfig.plist; sourceTree = "<group>"; };
 		D4ACFAE1468306F6BC08DB51 /* Pods-ProxUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		D7E6AA9F3734D8F66B0C39F3 /* Pods_ProxUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProxUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCBB957739FDB3296D165BBD /* Pods-ProxUITests.current location.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.current location.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.current location.xcconfig"; sourceTree = "<group>"; };
@@ -302,25 +304,26 @@
 		7B29E7C11DA3EC360099AF38 /* Prox */ = {
 			isa = PBXGroup;
 			children = (
-				7B29E7C21DA3EC360099AF38 /* AppDelegate.swift */,
-				7B29E7C91DA3EC360099AF38 /* Assets.xcassets */,
 				E6101A8F1DDA45CD00D05B74 /* Data.bundle */,
-				E65857E31DB6A75400CD18F8 /* Database */,
-				7BD5CC881DB0EB7400BCF50D /* GoogleService-Info.plist */,
+				D3DA77821DC289A4009C114E /* Prox-Bridging-Header.h */,
 				23039CD31DE56D5200653FCD /* APIKeys.plist */,
-				392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */,
-				39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */,
-				E67146341DB5488D007A99E4 /* Extensions */,
+				7BD5CC881DB0EB7400BCF50D /* GoogleService-Info.plist */,
 				7B29E7CE1DA3EC360099AF38 /* Info.plist */,
+				D3E2B3391E4BE7D10092882B /* LocalConfig.plist */,
+				392F3D961DD4395000B44B01 /* RemoteConfigDefaults.plist */,
+				7B29E7C21DA3EC360099AF38 /* AppDelegate.swift */,
+				E6F151461E25B73C001BDA6A /* MockLocationSelectionTableViewController.swift */,
+				39C4EC9C1DDB464200B53B77 /* RemoteConfigKeys.swift */,
+				7B29E7C91DA3EC360099AF38 /* Assets.xcassets */,
+				E65857E31DB6A75400CD18F8 /* Database */,
+				E67146341DB5488D007A99E4 /* Extensions */,
 				7B29E7CB1DA3EC360099AF38 /* LaunchScreen.storyboard */,
 				7B5095631DB531CA007C54F0 /* Models */,
 				7B561BB11DABD5730096D8BC /* Place Carousel */,
 				7B9DA1581DBE6F0A00A68C82 /* PlaceDetails */,
-				D3DA77821DC289A4009C114E /* Prox-Bridging-Header.h */,
 				7BD5CC601DAFF02100BCF50D /* ThirdParty */,
 				7B50956F1DB5352E007C54F0 /* Utilities */,
 				7B5095681DB53382007C54F0 /* Widgets */,
-				E6F151461E25B73C001BDA6A /* MockLocationSelectionTableViewController.swift */,
 			);
 			path = Prox;
 			sourceTree = "<group>";
@@ -663,6 +666,7 @@
 				392F3D971DD4395000B44B01 /* RemoteConfigDefaults.plist in Resources */,
 				23039CD41DE56D5200653FCD /* APIKeys.plist in Resources */,
 				7BD5CC891DB0EB7400BCF50D /* GoogleService-Info.plist in Resources */,
+				D3E2B33A1E4BE7D10092882B /* LocalConfig.plist in Resources */,
 				7B29E7CD1DA3EC360099AF38 /* LaunchScreen.storyboard in Resources */,
 				7B29E7CA1DA3EC360099AF38 /* Assets.xcassets in Resources */,
 				E6101A901DDA45CD00D05B74 /* Data.bundle in Resources */,

--- a/Prox/Prox/Utilities/AppConstants.swift
+++ b/Prox/Prox/Utilities/AppConstants.swift
@@ -80,7 +80,9 @@ public struct AppConstants {
             return "production/"
 
         case .Debug:
-            return ""
+            let configPath = Bundle.main.path(forResource: "LocalConfig", ofType: "plist")!
+            let plist = NSDictionary(contentsOfFile: configPath) as! [String: Any]
+            return "\(plist["DebugRoot"]!)/"
         }
     }()
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ your pods spec repo (this can take some time):
 
     pod repo update
 
-Install Pods:
+Run the checkout script:
 
-    pod install
+    ./checkout.sh
 
 Open the workspace. You will need to use the workspace to do development from
 now on. Attempting to compile the .xcodeproj by itself will result in

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -2,3 +2,4 @@
 
 cp $BUDDYBUILD_SECURE_FILES/GoogleService-Info.plist $BUDDYBUILD_WORKSPACE/Prox/Prox/GoogleService-Info.plist
 cp $BUDDYBUILD_SECURE_FILES/APIKeys.plist $BUDDYBUILD_WORKSPACE/Prox/Prox/APIKeys.plist
+./genconfig.sh

--- a/checkout.sh
+++ b/checkout.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Install necessary CocoaPods.
+pod install
+
+# Create the per-user config file.
+./genconfig.sh

--- a/genconfig.sh
+++ b/genconfig.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+root=$(whoami)
+read -d '' plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>DebugRoot</key>
+    <string>$root</string>
+</dict>
+</plist>
+EOF
+echo "$plist" > Prox/Prox/LocalConfig.plist


### PR DESCRIPTION
The current behavior for `AppConstants.firebaseRoot` isn't great. For one, the default path is "", meaning we try to read from the top level of the Firebase tree. Secondly, changing this path to point somewhere else (e.g., my own `brian/` branch) gets caught in version control.

I'd like to propose a local git-ignored config file, `LocalConfig.plist`. We can generate this file as part of a post-clone script, created in this PR, which includes `pod install`.

Note that I'm using `whoami` to set the login user name as the branch like we do in `prox-server`. If it's more useful, I could be convinced to make this script generate a plist that points to the shared `development/` instead.