### PR TITLE
Closes #569: Integrate hand-curated Discover data with client

### DIFF
--- a/Prox/Prox/Data/PlacesController.swift
+++ b/Prox/Prox/Data/PlacesController.swift
@@ -74,8 +74,14 @@ class PlacesProvider {
         var reviewCounts = [Int]()
 
         let distanceSortedPlaces = allPlaces.filter { place in
-            guard let firstFilter = place.categories.ids.flatMap({ CategoriesUtil.categoryToFilter[$0] }).first,
-                  enabledFilters.contains(firstFilter) else { return false }
+            let filter: PlaceFilter
+            if place.id.hasPrefix("proxdiscover-") {
+                filter = .discover
+            } else {
+                guard let firstFilter = place.categories.ids.flatMap({ CategoriesUtil.categoryToFilter[$0] }).first else { return false }
+                filter = firstFilter
+            }
+            guard enabledFilters.contains(filter) else { return false }
 
             reviewCounts.append(place.yelpProvider.totalReviewCount)
             return true

--- a/Prox/Prox/Models/Place.swift
+++ b/Prox/Prox/Models/Place.swift
@@ -12,6 +12,7 @@ private let YELP2_PATH = PROVIDERS_PATH + "yelp"
 private let YELP3_PATH = PROVIDERS_PATH + "yelp3"
 private let TRIP_ADVISOR_PATH = PROVIDERS_PATH + "tripAdvisor"
 private let WIKIPEDIA_PATH = PROVIDERS_PATH + "wikipedia"
+private let CUSTOM_PATH = PROVIDERS_PATH + "custom"
 
 typealias CachedTravelTime = (deferred: Deferred<DatabaseResult<TravelTimes>>, forLocation: CLLocation)
 
@@ -42,6 +43,7 @@ class Place: Hashable {
     let yelpProvider: PlaceProvider
     let tripAdvisorProvider: PlaceProvider?
     let wikipediaProvider: PlaceProvider?
+    let customProvider: PlaceProvider?
 
     init(id: String,
          name: String,
@@ -54,7 +56,8 @@ class Place: Hashable {
          totalReviewCount: Int = 0,
          yelpProvider: PlaceProvider,
          tripAdvisorProvider: PlaceProvider? = nil,
-         wikipediaProvider: PlaceProvider? = nil) {
+         wikipediaProvider: PlaceProvider? = nil,
+         customProvider: PlaceProvider? = nil) {
             self.id = id
             self.name = name
             self.categories = categories
@@ -67,6 +70,7 @@ class Place: Hashable {
             self.yelpProvider = yelpProvider
             self.tripAdvisorProvider = tripAdvisorProvider
             self.wikipediaProvider = wikipediaProvider
+            self.customProvider = customProvider
     }
 
     convenience init?(fromFirebaseSnapshot details: FIRDataSnapshot) {
@@ -90,7 +94,12 @@ class Place: Hashable {
             wikipediaProvider = SinglePlaceProvider(fromDictionary: wikipediaDict)
         }
 
-        let providers: [PlaceProvider?] = [yelpProvider, tripAdvisorProvider, wikipediaProvider]
+        var customProvider: SinglePlaceProvider?
+        if let customDict = details.childSnapshot(forPath: CUSTOM_PATH).value as? [String: Any] {
+            customProvider = SinglePlaceProvider(fromDictionary: customDict)
+        }
+
+        let providers: [PlaceProvider?] = [customProvider, yelpProvider, tripAdvisorProvider, wikipediaProvider]
         let compositeProvider = CompositePlaceProvider(fromProviders: providers.flatMap { $0 })
 
         guard let id = compositeProvider.id else {

--- a/Prox/Prox/Utilities/CategoriesUtil.swift
+++ b/Prox/Prox/Utilities/CategoriesUtil.swift
@@ -131,8 +131,15 @@ struct CategoriesUtil {
         var categoryToFilter = [String: PlaceFilter]()
 
         // Build the initial map of categories -> filters that we set explicitly.
-        for (filter, categories) in PlaceFilter.categories {
+        for (var filter, categories) in PlaceFilter.categories {
             for category in categories {
+                // Remap Discover -> Services for now. We're hand-curating Discover places, so
+                // the previously-categorized Discover places are no longer relevant. We use
+                // Services as a general uncategorized dumping ground since Services won't be
+                // included in the UI.
+                if filter == .discover {
+                    filter = .services
+                }
                 categoryToFilter[category] = filter
             }
         }


### PR DESCRIPTION
Two small commits that:
1) fix Discover to only list our hand-curated `proxdiscover` IDs, and
2) include the `custom` provider to generate Places.