### PR TITLE
Closes #598: always show closed places if we have open times

### DIFF
--- a/Prox/Prox/Models/Place.swift
+++ b/Prox/Prox/Models/Place.swift
@@ -366,7 +366,7 @@ struct OpenHours {
     private func getNextOpeningPeriod(fromOpeningPeriods openingPeriods: [OpenPeriodDates], forDate date: Date) -> OpenPeriodDates? {
         var nextOpenPeriod: OpenPeriodDates? = nil
         for openPeriod in openingPeriods {
-            if openPeriod.openTime > date {
+            if openPeriod.openTime >= date {
                 guard let currentNextOpenPeriod = nextOpenPeriod else {
                     nextOpenPeriod = openPeriod
                     break
@@ -415,6 +415,8 @@ struct OpenHours {
         var timeDateComponents = dateComponents(fromDate: date)
         timeDateComponents.hour = time.hour
         timeDateComponents.minute = time.minute
+        timeDateComponents.second = 0
+        timeDateComponents.nanosecond = 0
 
         return OpenHours.calendar.date(from: timeDateComponents)
     }

--- a/Prox/Prox/Models/Place.swift
+++ b/Prox/Prox/Models/Place.swift
@@ -421,24 +421,29 @@ struct OpenHours {
         return OpenHours.calendar.date(from: timeDateComponents)
     }
 
-    func getEarliestOpeningPeriod(forDate date: Date) -> OpenPeriodDates? {
-        guard let allOpeningPeriods = getOpeningTimes(forDate: date) else {
-            return nil
-        }
-        return getEarliestOpeningPeriod(fromOpeningPeriods: allOpeningPeriods)
-    }
+    func nextOpeningTime(forTime baseTime: Date) -> String? {
+        let midnight = DateComponents(hour: 0, minute: 0)
+        let times = [baseTime] + (1...7).map { getDate(forTime: midnight, onDate: baseTime.addingTimeInterval(TimeInterval($0) * AppConstants.ONE_DAY))! }
 
-    func nextOpeningTime(forTime time: Date) -> String? {
-        guard let allOpeningTimes = getOpeningTimes(forDate: time),
-            let openingPeriod = getNextOpeningPeriod(fromOpeningPeriods: allOpeningTimes, forDate: time) else {
-            // get tomorrows earliest opening time if possible
-            if let openingPeriod = getEarliestOpeningPeriod(forDate: time + AppConstants.ONE_DAY) {
+        for time in times {
+            guard let allOpeningTimes = getOpeningTimes(forDate: time),
+                  let openingPeriod = getNextOpeningPeriod(fromOpeningPeriods: allOpeningTimes, forDate: time) else {
+                continue
+            }
+
+            if OpenHours.calendar.isDate(time, inSameDayAs: baseTime) {
                 return timeString(forDate: openingPeriod.openTime)
             }
-            return nil
+
+            if OpenHours.calendar.isDate(time, inSameDayAs: baseTime.addingTimeInterval(AppConstants.ONE_DAY)) {
+                return Strings.place.tomorrow
+            }
+
+            // Returns the localized day of week.
+            return DateFormatter().weekdaySymbols[OpenHours.calendar.component(.weekday, from: time) - 1]
         }
 
-        return timeString(forDate: openingPeriod.openTime)
+        return nil
     }
 
     func closingTime(forTime time: Date) -> String? {

--- a/Prox/Prox/Utilities/Strings.swift
+++ b/Prox/Prox/Utilities/Strings.swift
@@ -18,4 +18,8 @@ struct Strings {
         static let noInfo = "No info"
         static let numReviews = "%d Review%@"
     }
+
+    struct place {
+        static let tomorrow = "tomorrow"
+    }
 }

--- a/Prox/ProxTests/OpenHoursTests.swift
+++ b/Prox/ProxTests/OpenHoursTests.swift
@@ -234,8 +234,10 @@ class OpenHoursTests: XCTestCase {
         let opening = dateComponents(withHour: 7, minute: 0)
         let closing = dateComponents(withHour: 14, minute: 30)
         let tuesdayOpening = dateComponents(withHour: 10, minute: 0)
+        let wednesdayOpening = dateComponents(withHour: 0, minute: 0)
         let hours = OpenHours(hours: [.monday : [(openTime: opening, closeTime: closing)],
-                                      .tuesday : [(openTime: tuesdayOpening, closeTime: closing)]])
+                                      .tuesday : [(openTime: tuesdayOpening, closeTime: closing)],
+                                      .wednesday : [(openTime: wednesdayOpening, closeTime: closing)]])
 
         var testDate = monday(atHour: 6, minute: 59)
 
@@ -243,8 +245,16 @@ class OpenHoursTests: XCTestCase {
         XCTAssertEqual(hours.nextOpeningTime(forTime: testDate), "7:00 AM")
         XCTAssertEqual(hours.closingTime(forTime: testDate), "2:30 PM")
 
-        // we are now past the opening time for today, so we are expecting tomorrows opening time to be returned from nextOpeningTime
+        // If today's hours are done, show "tomorrow".
         testDate = monday(atHour: 14, minute: 01)
-        XCTAssertEqual(hours.nextOpeningTime(forTime: testDate), "10:00 AM")
+        XCTAssertEqual(hours.nextOpeningTime(forTime: testDate), "tomorrow")
+
+        // If the hours start at midnight, also show that as "tomorrow".
+        testDate = tuesday(atHour: 10, minute: 1)
+        XCTAssertEqual(hours.nextOpeningTime(forTime: testDate), "tomorrow")
+
+        // Both days have passed, so look ahead to next week.
+        testDate = wednesday(atHour: 0, minute: 1)
+        XCTAssertEqual(hours.nextOpeningTime(forTime: testDate), "Monday")
     }
 }


### PR DESCRIPTION
The behavior we want here is to:
1) Show the opening time if the event is later today,
2) Show "tomorrow" if the event is tomorrow, and
3) Show the day of week if the event is any later.

It was kinda hard to wrap my head around our existing `OpenHours` API, but I think this works. Since our open hours are stored and partitioned by day, and since `getOpeningTimes` only returns time on the day of the date provided, this iterates through each day until we get a result. Note that the first date we iterate over is today including the time since we don't want to show events from earlier in the day; other dates we iterate over use 0:00 so that `getOpeningTimes` doesn't skip it.

This also changes `getNextOpeningPeriod` from `>` to `>=` so we include future events that start at midnight.