### PR TITLE
Closes #543: add timeout when calculating travel ETAs

### DIFF
--- a/Prox/Prox.xcodeproj/project.pbxproj
+++ b/Prox/Prox.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		D3656D981E4A7D0F00040448 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3656D971E4A7D0F00040448 /* Logger.swift */; };
 		D3C815681E4542E30066A97B /* PlaceProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C815671E4542E30066A97B /* PlaceProviders.swift */; };
 		D3D6F5C21E60E8140093BFD4 /* PlaceFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D6F5C11E60E8130093BFD4 /* PlaceFilter.swift */; };
+		D3F698201E70D35200464641 /* Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F6981F1E70D35200464641 /* Future.swift */; };
 		E60A42711DF28E01008BE74D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A42701DF28E01008BE74D /* URL.swift */; };
 		E60A42771DF29127008BE74D /* URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A42761DF29127008BE74D /* URLTests.swift */; };
 		E6101A901DDA45CD00D05B74 /* Data.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E6101A8F1DDA45CD00D05B74 /* Data.bundle */; };
@@ -224,6 +225,7 @@
 		D3D6F5C11E60E8130093BFD4 /* PlaceFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceFilter.swift; sourceTree = "<group>"; };
 		D3DA777E1DC2776C009C114E /* BuddyBuildSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BuddyBuildSDK.framework; path = ../Pods/BuddyBuildSDK/BuddyBuildSDK.framework; sourceTree = "<group>"; };
 		D3DA77821DC289A4009C114E /* Prox-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Prox-Bridging-Header.h"; sourceTree = "<group>"; };
+		D3F6981F1E70D35200464641 /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = Extensions/Future.swift; sourceTree = "<group>"; };
 		D4ACFAE1468306F6BC08DB51 /* Pods-ProxUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		D7E6AA9F3734D8F66B0C39F3 /* Pods_ProxUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProxUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCBB957739FDB3296D165BBD /* Pods-ProxUITests.current location.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProxUITests.current location.xcconfig"; path = "../Pods/Target Support Files/Pods-ProxUITests/Pods-ProxUITests.current location.xcconfig"; sourceTree = "<group>"; };
@@ -576,14 +578,15 @@
 		E67146341DB5488D007A99E4 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				E6CF08DD1E57B61C0083CAD8 /* Google Maps */,
+				E69D69861E6E27DE00E6F6CA /* CLLocation.swift */,
 				E67146351DB54896007A99E4 /* CLLocationManager.swift */,
+				E6CF08DD1E57B61C0083CAD8 /* Google Maps */,
+				D3F6981F1E70D35200464641 /* Future.swift */,
 				7B5095741DB62590007C54F0 /* NSLayoutConstraint.swift */,
+				23739F5B1E70B74C00C6323B /* String.swift */,
 				7B1C657C1DDF28F00047559C /* TimeInterval.swift */,
 				D32F73ED1E4D07AE00D504A7 /* UIColor.swift */,
 				E60A42701DF28E01008BE74D /* URL.swift */,
-				E69D69861E6E27DE00E6F6CA /* CLLocation.swift */,
-				23739F5B1E70B74C00C6323B /* String.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -903,6 +906,7 @@
 				D3C815681E4542E30066A97B /* PlaceProviders.swift in Sources */,
 				7B9D15C81DC0D51C0051B760 /* OpenInFirefoxControllerSwift.swift in Sources */,
 				E62CE0C11E5786BE0083FA7B /* Prompts.swift in Sources */,
+				D3F698201E70D35200464641 /* Future.swift in Sources */,
 				E63C346F1DDCDFBB005B6B15 /* LocationLoadingView.swift in Sources */,
 				7B5095721DB5352E007C54F0 /* Colors.swift in Sources */,
 				7B48EBDA1DD1F679005C36CB /* GeofenceRegion.swift in Sources */,

--- a/Prox/Prox/Extensions/Future.swift
+++ b/Prox/Prox/Extensions/Future.swift
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Deferred
+
+extension FutureProtocol {
+    /// Returns a Future resolved with the result of this Future, or nil
+    /// if this Future isn't resolved by the deadline.
+    func timeout(deadline: DispatchTime) -> Future<Value?> {
+        let deferred = Deferred<Value?>()
+        let queue = DefaultExecutor.any()
+        upon(queue) { result in deferred.fill(with: result) }
+        queue.asyncAfter(deadline: deadline) { deferred.fill(with: self.peek()) }
+        return Future(deferred)
+    }
+}


### PR DESCRIPTION
I found that `MKDirections.calculateETA` simply isn't executing its callback at all, which seems like an iOS bug. I added a delayed dispatch on the main thread to see if maybe the main thread is deadlocked and we're seeing this as a side effect, but the dispatched callback executes just fine after the app freezes.

Was originally going to sort by raw distance and update the walking distance only as the cards are shown, but that would slightly reorder the cards, which is risky given the closeness to Chicago. Adding a timeout is probably the safest bet for now since it doesn't change the experience.