### PR TITLE
No issue: upgrade deps

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,33 +5,33 @@ use_frameworks!
 
 target 'Prox' do
 	pod 'AFNetworking', '~> 3.0'
-	pod 'BNRDeferred', '~> 3.0-beta'
-	pod 'Firebase/Core'
-	pod 'Firebase/Database'
-	pod 'Firebase/Auth'
-	pod 'Firebase/RemoteConfig'
-	pod 'Flurry-iOS-SDK/FlurrySDK'
-	pod 'BuddyBuildSDK'
+	pod 'BNRDeferred', '~> 3.0'
+	pod 'Firebase/Core', '~> 3.15'
+	pod 'Firebase/Database', '~> 3.15'
+	pod 'Firebase/Auth', '~> 3.15'
+	pod 'Firebase/RemoteConfig', '~> 3.15'
+	pod 'Flurry-iOS-SDK', '~> 7.10'
+	pod 'BuddyBuildSDK', '~> 1.0'
 	pod 'FXPageControl', '1.4'
-	pod 'GoogleMaps'
+	pod 'GoogleMaps', '~> 2.2'
 	pod 'SnapKit', '~> 3.2.0'
 end
 
 target 'ProxTests' do
 	pod 'AFNetworking', '~> 3.0'
-	pod 'BNRDeferred', '~> 3.0-beta'
-	pod 'Firebase/Core'
-	pod 'Firebase/Database'
-	pod 'Firebase/Auth'
+	pod 'BNRDeferred', '~> 3.0'
+	pod 'Firebase/Core', '~> 3.15'
+	pod 'Firebase/Database', '~> 3.15'
+	pod 'Firebase/Auth', '~> 3.15'
 	pod 'FXPageControl', '1.4'
 end
 
 target 'ProxUITests' do
 	pod 'AFNetworking', '~> 3.0'
-	pod 'BNRDeferred', '~> 3.0-beta'
-	pod 'Firebase/Core'
-	pod 'Firebase/Database'
-	pod 'Firebase/Auth'
-	pod 'Firebase/RemoteConfig'
+	pod 'BNRDeferred', '~> 3.0'
+	pod 'Firebase/Core', '~> 3.15'
+	pod 'Firebase/Database', '~> 3.15'
+	pod 'Firebase/Auth', '~> 3.15'
+	pod 'Firebase/RemoteConfig', '~> 3.15'
 	pod 'FXPageControl', '1.4'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -46,6 +46,8 @@ PODS:
     - FirebaseInstanceID (~> 1.0)
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
     - Protobuf (~> 3.1)
+  - Flurry-iOS-SDK (7.10.0):
+    - Flurry-iOS-SDK/FlurrySDK (= 7.10.0)
   - Flurry-iOS-SDK/FlurrySDK (7.10.0)
   - FXPageControl (1.4)
   - GoogleMaps (2.2.0):
@@ -69,15 +71,15 @@ PODS:
 
 DEPENDENCIES:
   - AFNetworking (~> 3.0)
-  - BNRDeferred (~> 3.0-beta)
-  - BuddyBuildSDK
-  - Firebase/Auth
-  - Firebase/Core
-  - Firebase/Database
-  - Firebase/RemoteConfig
-  - Flurry-iOS-SDK/FlurrySDK
+  - BNRDeferred (~> 3.0)
+  - BuddyBuildSDK (~> 1.0)
+  - Firebase/Auth (~> 3.15)
+  - Firebase/Core (~> 3.15)
+  - Firebase/Database (~> 3.15)
+  - Firebase/RemoteConfig (~> 3.15)
+  - Flurry-iOS-SDK (~> 7.10)
   - FXPageControl (= 1.4)
-  - GoogleMaps
+  - GoogleMaps (~> 2.2)
   - SnapKit (~> 3.2.0)
 
 SPEC CHECKSUMS:
@@ -99,6 +101,6 @@ SPEC CHECKSUMS:
   Protobuf: 745f59e122e5de98d4d7ef291e264a0eef80f58e
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
 
-PODFILE CHECKSUM: 843ad2bca1fcc5b797befacdb8ac81af0dc54cd3
+PODFILE CHECKSUM: 1bc30d0f0f65b895859fea1bbe21d6c4db352868
 
 COCOAPODS: 1.2.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,63 +14,57 @@ PODS:
   - AFNetworking/Serialization (3.1.0)
   - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
-  - BNRDeferred (3.0.0-beta.3)
-  - BuddyBuildSDK (1.0.12)
-  - Firebase/Auth (3.8.0):
+  - BNRDeferred (3.0.0)
+  - BuddyBuildSDK (1.0.14)
+  - Firebase/Auth (3.15.0):
     - Firebase/Core
-    - FirebaseAuth (= 3.0.6)
-  - Firebase/Core (3.8.0):
-    - FirebaseAnalytics (= 3.5.1)
-    - FirebaseCore (= 3.4.4)
-  - Firebase/Database (3.8.0):
+    - FirebaseAuth (= 3.1.1)
+  - Firebase/Core (3.15.0):
+    - FirebaseAnalytics (= 3.7.0)
+    - FirebaseCore (= 3.5.2)
+  - Firebase/Database (3.15.0):
     - Firebase/Core
-    - FirebaseDatabase (= 3.1.0)
-  - Firebase/RemoteConfig (3.8.0):
+    - FirebaseDatabase (= 3.1.2)
+  - Firebase/RemoteConfig (3.15.0):
     - Firebase/Core
-    - FirebaseRemoteConfig (= 1.3.1)
-  - FirebaseAnalytics (3.5.1):
-    - FirebaseCore (~> 3.4)
+    - FirebaseRemoteConfig (= 1.3.4)
+  - FirebaseAnalytics (3.7.0):
+    - FirebaseCore (~> 3.5)
     - FirebaseInstanceID (~> 1.0)
-    - GoogleInterchangeUtilities (~> 1.2)
-    - GoogleSymbolUtilities (~> 1.1)
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
-  - FirebaseAuth (3.0.6):
-    - FirebaseAnalytics (~> 3.4)
+  - FirebaseAuth (3.1.1):
+    - FirebaseAnalytics (~> 3.7)
     - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseCore (3.4.4):
-    - GoogleInterchangeUtilities (~> 1.2)
+  - FirebaseCore (3.5.2):
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
-  - FirebaseDatabase (3.1.0):
-    - FirebaseAnalytics (~> 3.4)
-  - FirebaseInstanceID (1.0.8)
-  - FirebaseRemoteConfig (1.3.1):
-    - FirebaseAnalytics (~> 3.4)
+  - FirebaseDatabase (3.1.2):
+    - FirebaseAnalytics (~> 3.7)
+  - FirebaseInstanceID (1.0.9)
+  - FirebaseRemoteConfig (1.3.4):
+    - FirebaseAnalytics (~> 3.7)
     - FirebaseInstanceID (~> 1.0)
-    - GoogleInterchangeUtilities (~> 1.2)
-    - GoogleSymbolUtilities (~> 1.1)
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
-  - Flurry-iOS-SDK/FlurrySDK (7.8.1)
+    - Protobuf (~> 3.1)
+  - Flurry-iOS-SDK/FlurrySDK (7.10.0)
   - FXPageControl (1.4)
-  - GoogleInterchangeUtilities (1.2.2):
-    - GoogleSymbolUtilities (~> 1.1)
-  - GoogleMaps (2.1.1):
-    - GoogleMaps/Maps (= 2.1.1)
-  - GoogleMaps/Base (2.1.1)
-  - GoogleMaps/Maps (2.1.1):
+  - GoogleMaps (2.2.0):
+    - GoogleMaps/Maps (= 2.2.0)
+  - GoogleMaps/Base (2.2.0)
+  - GoogleMaps/Maps (2.2.0):
     - GoogleMaps/Base
-  - GoogleSymbolUtilities (1.1.2)
-  - GoogleToolboxForMac/DebugUtils (2.1.0):
-    - GoogleToolboxForMac/Defines (= 2.1.0)
-  - GoogleToolboxForMac/Defines (2.1.0)
-  - GoogleToolboxForMac/NSData+zlib (2.1.0):
-    - GoogleToolboxForMac/Defines (= 2.1.0)
-  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.0):
-    - GoogleToolboxForMac/DebugUtils (= 2.1.0)
-    - GoogleToolboxForMac/Defines (= 2.1.0)
-    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.0)
-  - GoogleToolboxForMac/NSString+URLArguments (2.1.0)
-  - GTMSessionFetcher/Core (1.1.7)
+  - GoogleToolboxForMac/DebugUtils (2.1.1):
+    - GoogleToolboxForMac/Defines (= 2.1.1)
+  - GoogleToolboxForMac/Defines (2.1.1)
+  - GoogleToolboxForMac/NSData+zlib (2.1.1):
+    - GoogleToolboxForMac/Defines (= 2.1.1)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.1):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.1)
+    - GoogleToolboxForMac/Defines (= 2.1.1)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.1)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.1)
+  - GTMSessionFetcher/Core (1.1.9)
+  - Protobuf (3.2.0)
   - SnapKit (3.2.0)
 
 DEPENDENCIES:
@@ -88,22 +82,21 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
-  BNRDeferred: 17042a76318cc1f23af85f1ee4fad4cc3172f272
-  BuddyBuildSDK: f4682598772ae66c9ef5554d2d78d0a19fb413a0
-  Firebase: fdbecadb7b5cbef2774852d4fa659b9daf11f2af
-  FirebaseAnalytics: 6e58fc9b397664369ac7617fb0ba93fab6ba7b5b
-  FirebaseAuth: 96e9674ff31d6e1f826d53e26aa003a57cab0295
-  FirebaseCore: d0ed25f27b6f9158eccc439f1be6f92e81207e28
-  FirebaseDatabase: 3ebb2edb6007c3f0f87b248f3fa212bde56a1468
-  FirebaseInstanceID: ba1e640935235e5fac39dfa816fe7660e72e1a8a
-  FirebaseRemoteConfig: 383a9afe0a9291ada949e3f615257928a823b594
-  Flurry-iOS-SDK: 3d1daff95d43b8fead3bb43590d54c6e8244d410
+  BNRDeferred: 0757b256613622d3f3db21bd126ba63031ca3deb
+  BuddyBuildSDK: 2b2d35a61ad7fd3645beb2d48bc5123efd869918
+  Firebase: 2b1cdfba1cda8589f32904a697cc753322bff9d8
+  FirebaseAnalytics: 0d1b7d81d5021155be37702a94ba1ec16d45365d
+  FirebaseAuth: cc8a1824170adbd351edb7f994490a3fb5c18be6
+  FirebaseCore: a024587e43778508700af8c6b1209f7c4516ba02
+  FirebaseDatabase: 05c96d7b43a7368dc91c07791adb49683e1738d1
+  FirebaseInstanceID: 2d0518b1378fe9d685ef40cbdd63d2fdc1125339
+  FirebaseRemoteConfig: af3003f4e8daa2bd1d5cf90d3cccc1fe224f8ed9
+  Flurry-iOS-SDK: e6975df9e57010d582bf9bed0f6312553cf24bc2
   FXPageControl: 5057bf21537579b40ff30e119cd425d16d8ef90a
-  GoogleInterchangeUtilities: d5bc4d88d5b661ab72f9d70c58d02ca8c27ad1f7
-  GoogleMaps: a5b5bbe47734e2443bde781a6aa64e69fdb6d785
-  GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
-  GoogleToolboxForMac: 2b2596cbb7186865e98cadf2b1e262d851c2b168
-  GTMSessionFetcher: a1f8ed39e4fe21c68957daed472c7afbcdf29166
+  GoogleMaps: 104c418d61ab8a05dff06ed0784c25ea9d37da45
+  GoogleToolboxForMac: 8e329f1b599f2512c6b10676d45736bcc2cbbeb0
+  GTMSessionFetcher: 5c046c76a1f859bc9c187e918f18e4fc7bb57b5e
+  Protobuf: 745f59e122e5de98d4d7ef291e264a0eef80f58e
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
 
 PODFILE CHECKSUM: 843ad2bca1fcc5b797befacdb8ac81af0dc54cd3


### PR DESCRIPTION
I *think* devs will need to run `pod install` to upgrade their deps after this patch.